### PR TITLE
Fix LANGS list in ReadAlongs align and views

### DIFF
--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -27,8 +27,6 @@ from tempfile import TemporaryFile
 
 import click
 from flask.cli import FlaskGroup
-from g2p.mappings.langs import LANGS_AVAILABLE, LANGS_NETWORK
-from networkx import has_path
 
 from readalongs._version import __version__
 from readalongs.align import (
@@ -45,18 +43,7 @@ from readalongs.epub.create_epub import create_epub
 from readalongs.log import LOGGER
 from readalongs.text.make_smil import make_smil
 from readalongs.text.util import save_minimal_index_html, save_txt, save_xml
-
-# get the key from all networks in text module that have a path to 'eng-arpabet'
-# which is needed for the readalongs
-LANGS = [
-    k
-    for x in LANGS_AVAILABLE
-    for k in x.keys()
-    if LANGS_NETWORK.has_node(k) and has_path(LANGS_NETWORK, k, "eng-arpabet")
-]
-
-# Hack to allow old English LexiconG2P
-LANGS += ["eng"]
+from readalongs.views import LANGS
 
 
 def create_app():

--- a/readalongs/views.py
+++ b/readalongs/views.py
@@ -27,13 +27,24 @@ from networkx import has_path
 from readalongs.app import app, socketio
 from readalongs.log import LOGGER
 
+
 # LANGS_AVAILABLE in g2p lists langs inferred by the directory structure of
 # g2p/mappings/langs, but in ReadAlongs, we need all input languages to any mappings.
 # E.g., for Michif, we need to allow crg-dv and crg-tmd, but not crg, which is what
 # LANGS_AVAILABLE contains. So we define our own list of languages here.
-LANGS_AVAILABLE = [
-    mapping["in_lang"] for k, v in g2p_langs.LANGS.items() for mapping in v["mappings"]
-]
+LANGS_AVAILABLE = []
+
+# Set up LANG_NAMES hash table for studio UI to
+# properly name the dropdown options
+LANG_NAMES = {"eng": "English"}
+
+for k, v in g2p_langs.LANGS.items():
+    for mapping in v["mappings"]:
+        # add mapping to names hash table
+        LANG_NAMES[mapping["in_lang"]] = mapping["language_name"]
+        # add input id to all available langs list
+        if mapping['in_lang'] not in LANGS_AVAILABLE:
+            LANGS_AVAILABLE.append(mapping["in_lang"])
 
 # get the key from all networks in g2p module that have a path to 'eng-arpabet',
 # which is needed for the readalongs
@@ -178,12 +189,13 @@ def steps(step):
         session["temp_dir"] = mkdtemp()
         temp_dir = session["temp_dir"]
         return render_template(
-            "upload.html", uploaded=uploaded_files(temp_dir), maps=LANGS
+            "upload.html",
+            uploaded=uploaded_files(temp_dir),
+            maps=[{"code": m, "name": LANG_NAMES[m]} for m in LANGS],
         )
     elif step == 2:
         return render_template("preview.html")
     elif step == 3:
-        timestamp = str(int(datetime.now().timestamp()))
         if "audio" not in session or "text" not in session:
             log = "Sorry, it looks like something is wrong with your audio or text. Please try again"
         else:
@@ -195,6 +207,7 @@ def steps(step):
                 flags.append("--text-input")
                 flags.append("--language")
                 flags.append(session["config"]["lang"])
+            timestamp = str(int(datetime.now().timestamp()))
             output_base = "aligned" + timestamp
             args = (
                 ["readalongs", "align"]
@@ -237,7 +250,7 @@ def show_zip(base):
         "temp_dir" not in session
         or not os.path.exists(session["temp_dir"])
         or not files_to_download
-        or not any([x.startswith("aligned") for x in files_to_download])
+        or not any(x.startswith("aligned") for x in files_to_download)
     ):
         return abort(
             404, "Nothing to download. Please go to Step 1 of the Read Along Studio"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==4.3.0
 networkx==2.3
 numpy>=1.16.4
 panphon>=0.14
-soundswallower==0.1.2
+soundswallower==0.1.1
 pydub==0.23.1
 pympi-ling==1.69
 python-slugify==1.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ lxml==4.3.0
 networkx==2.3
 numpy>=1.16.4
 panphon>=0.14
-soundswallower==0.1.1
+soundswallower==0.1.2
 pydub==0.23.1
 pympi-ling==1.69
 python-slugify==1.2.6

--- a/test/test_align_cli.py
+++ b/test/test_align_cli.py
@@ -87,6 +87,14 @@ class TestAlignCli(TestCase):
         ) as f2:
             self.assertListEqual(list(f1), list(f2))
 
+    def test_align_help(self):
+        # Validates that readalongs align -h lists all in-langs that can map to eng-arpabet
+        results = self.runner.invoke(align, "-h")
+        self.assertEqual(results.exit_code, 0)
+        self.assertIn("|crg-tmd|", results.stdout)
+        self.assertIn("|crg-dv|", results.stdout)
+        self.assertNotIn("|crg|", results.stdout)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes https://github.com/roedoejet/g2p/issues/70

`LANGS_AVAILABLE` defined in `g2p` does not list all languages, so don't use it to define `LANGS` in ReadAlongs/Studio.

Tested for readalongs align (changes in `cli.py`), but not for `views.py`, where the same list is used, and where I therefore believe the change was also needed. The unit test suite does not exercise the code in `views.py` that uses `LANGS`, namely `step()`, and I don't know how to exercise it, so that should ideally get tested before merging this PR in.

This patch is required to successfully run `readalongs align` on any Michif data, since `crg-dv` and `crg-tmd` were not found in LANGS before this patch.