### PR TITLE
Adding `readalongs tokenize` to CLI, and improve `readalongs prepare`

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -548,7 +548,7 @@ def create_input_xml(
     return outfile, filename
 
 
-def create_input_tei(text, **kwargs):
+def create_input_tei(**kwargs):
     """ Create input xml in TEI standard.
         Uses readlines to infer paragraph and sentence structure from plain text.
         TODO: Check if path, if it's just plain text, then render that instead of reading from the file
@@ -557,8 +557,10 @@ def create_input_tei(text, **kwargs):
 
     Parameters
     ----------
-    text : str
-        raw input text
+    **input_file_name : Union[str, None]
+        raw input text file name
+    **input_file_handle : Union[file_handle, None]
+        opened input file handle for input text - only provide one of input_file_name or input_file_handle!
     **text_language in kwargs : str
         language for the text.
     **save_temps in kwargs : Union[str, None], optional
@@ -573,8 +575,16 @@ def create_input_tei(text, **kwargs):
     str
         filename
     """
-    with io.open(text, encoding="utf-8") as f:
-        text = f.readlines()
+    if kwargs.get("input_file_name", False):
+        with io.open(kwargs["input_file_name"]) as f:
+            text = f.readlines()
+    elif kwargs.get("input_file_handle", False):
+        text = kwargs["input_file_handle"].readlines()
+    else:
+        raise RuntimeError(
+            "Call create_input_tei with exactly one of input_file_name= or input_file_handle="
+        )
+
     save_temps = kwargs.get("save_temps", False)
     if kwargs.get("output_file", False):
         filename = kwargs.get("output_file")

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -383,7 +383,10 @@ def tokenize(**kwargs):
     xmlfile = kwargs["xmlfile"]
 
     if not kwargs["tokfile"]:
-        output_tok_path = xmlfile.name
+        try:
+            output_tok_path = xmlfile.name
+        except Exception:
+            output_tok_path = "<stdin>"
         if output_tok_path == "<stdin>":
             output_tok_path = "-"
         else:
@@ -403,7 +406,11 @@ def tokenize(**kwargs):
     try:
         xml = etree.parse(xmlfile).getroot()
     except etree.XMLSyntaxError as e:
-        raise RuntimeError("Error parsing XML input file %s: %s." % (xmlfile, e))
+        raise click.BadParameter(
+            "Error parsing input file %s as XML, please verify it. Parser error: %s"
+            % (xmlfile, e)
+        )
+
     xml = tokenize_xml(xml)
 
     if output_tok_path == "-":

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -311,6 +311,7 @@ def prepare(**kwargs):
 
     XMLFILE:       Path to the XML output file, or - for stdout [default: PLAINTEXTFILE.xml]
     """
+
     if kwargs["debug"]:
         LOGGER.setLevel("DEBUG")
         LOGGER.info(
@@ -381,6 +382,16 @@ def tokenize(**kwargs):
     TOKFILE: Output path for the tok'd XML, or - for stdout [default: XMLFILE.tokenized.xml]
     """
     xmlfile = kwargs["xmlfile"]
+
+    if kwargs["debug"]:
+        LOGGER.setLevel("DEBUG")
+        LOGGER.info(
+            "Running readalongs tokenize(xmlfile={}, tokfile={}, force-overwrite={}).".format(
+                kwargs["xmlfile"],
+                kwargs["tokfile"],
+                kwargs["force_overwrite"],
+            )
+        )
 
     if not kwargs["tokfile"]:
         try:

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -20,9 +20,11 @@
 #
 #######################################################################
 
+import io
 import json
 import os
 import shutil
+import sys
 from tempfile import TemporaryFile
 
 import click
@@ -44,7 +46,7 @@ from readalongs.epub.create_epub import create_epub
 from readalongs.log import LOGGER
 from readalongs.text.make_smil import make_smil
 from readalongs.text.tokenize_xml import tokenize_xml
-from readalongs.text.util import save_minimal_index_html, save_txt, save_xml
+from readalongs.text.util import save_minimal_index_html, save_txt, save_xml, write_xml
 from readalongs.views import LANGS
 
 
@@ -182,7 +184,9 @@ def align(**kwargs):
         if not kwargs["language"]:
             LOGGER.warn("No input language provided, using undetermined mapping")
         tempfile, kwargs["textfile"] = create_input_tei(
-            kwargs["textfile"], text_language=kwargs["language"], save_temps=temp_base,
+            input_file_name=kwargs["textfile"],
+            text_language=kwargs["language"],
+            save_temps=temp_base,
         )
     if kwargs["output_xhtml"]:
         tokenized_xml_path = "%s.xhtml" % output_base
@@ -284,8 +288,8 @@ def epub(**kwargs):
     context_settings=CONTEXT_SETTINGS,
     short_help="Prepare XML input to align from plain text.",
 )
-@click.argument("plaintextfile", type=click.Path(exists=True, readable=True))
-@click.argument("xmlfile", type=click.Path())
+@click.argument("plaintextfile", type=click.File("rb"))
+@click.argument("xmlfile", type=click.Path(), required=False, default="")
 @click.option("-d", "--debug", is_flag=True, help="Add debugging messages to logger")
 @click.option(
     "-f", "--force-overwrite", is_flag=True, help="Force overwrite output files"
@@ -303,9 +307,9 @@ def prepare(**kwargs):
     paragraph breaks marked by a blank line, and page breaks marked by two
     blank lines.
 
-    PLAINTEXTFILE: Path to the plain text input file
+    PLAINTEXTFILE: Path to the plain text input file, or - for stdin
 
-    XMLFILE:       Path to the XML output file
+    XMLFILE:       Path to the XML output file, or - for stdout [default: PLAINTEXTFILE.xml]
     """
     if kwargs["debug"]:
         LOGGER.setLevel("DEBUG")
@@ -318,17 +322,42 @@ def prepare(**kwargs):
             )
         )
 
-    xmlpath = kwargs["xmlfile"]
-    if not xmlpath.endswith(".xml"):
-        xmlpath += ".xml"
-    if os.path.exists(xmlpath) and not kwargs["force_overwrite"]:
-        raise click.BadParameter(
-            "Output file %s exists already, use -f to overwrite." % xmlpath
+    input_file = kwargs["plaintextfile"]
+
+    out_file = kwargs["xmlfile"]
+    if not out_file:
+        try:
+            out_file = input_file.name
+        except Exception:  # For unit testing: simulated stdin stream has no .name attrib
+            out_file = "<stdin>"
+        if out_file == "<stdin>":  # actual intput_file.name when cli input is "-"
+            out_file = "-"
+        else:
+            if out_file.endswith(".txt"):
+                out_file = out_file[:-4]
+            out_file += ".xml"
+
+    if out_file == "-":
+        filehandle, filename = create_input_tei(
+            input_file_handle=input_file, text_language=kwargs["language"],
         )
-    filehandle, filename = create_input_tei(
-        kwargs["plaintextfile"], text_language=kwargs["language"], output_file=xmlpath
-    )
-    LOGGER.info("Wrote {}".format(xmlpath))
+        with io.open(filename) as f:
+            sys.stdout.write(f.read())
+    else:
+        if not out_file.endswith(".xml"):
+            out_file += ".xml"
+        if os.path.exists(out_file) and not kwargs["force_overwrite"]:
+            raise click.BadParameter(
+                "Output file %s exists already, use -f to overwrite." % out_file
+            )
+
+        filehandle, filename = create_input_tei(
+            input_file_handle=input_file,
+            text_language=kwargs["language"],
+            output_file=out_file,
+        )
+
+    LOGGER.info("Wrote {}".format(out_file))
 
 
 @app.cli.command(
@@ -347,21 +376,29 @@ def tokenize(**kwargs):
     TOKFILE can be augmented with word-specific language codes.
     'readalongs align' can be called with either XMLFILE or TOKFILE as XML input.
 
-    XMLFILE: Path to the XML file to tokenize
+    XMLFILE: Path to the XML file to tokenize, or - for stdin
 
-    TOKFILE: Path to the tokenized XML output file [XMLFILE.tokenized.xml]
+    TOKFILE: Output path for the tok'd XML, or - for stdout [default: XMLFILE.tokenized.xml]
     """
     xmlfile = kwargs["xmlfile"]
 
     if not kwargs["tokfile"]:
         output_tok_path = xmlfile.name
-        if output_tok_path.endswith(".xml"):
-            output_tok_path = output_tok_path[:-4]
-        output_tok_path += ".tokenized.xml"
+        if output_tok_path == "<stdin>":
+            output_tok_path = "-"
+        else:
+            if output_tok_path.endswith(".xml"):
+                output_tok_path = output_tok_path[:-4]
+            output_tok_path += ".tokenized.xml"
     else:
         output_tok_path = kwargs["tokfile"]
-    if not output_tok_path.endswith(".xml"):
-        output_tok_path += ".xml"
+        if not output_tok_path.endswith(".xml") and not output_tok_path == "-":
+            output_tok_path += ".xml"
+
+    if os.path.exists(output_tok_path) and not kwargs["force_overwrite"]:
+        raise click.BadParameter(
+            "Output file %s exists already, use -f to overwrite." % output_tok_path
+        )
 
     try:
         xml = etree.parse(xmlfile).getroot()
@@ -369,8 +406,8 @@ def tokenize(**kwargs):
         raise RuntimeError("Error parsing XML input file %s: %s." % (xmlfile, e))
     xml = tokenize_xml(xml)
 
-    if os.path.exists(output_tok_path) and not kwargs["force_overwrite"]:
-        raise click.BadParameter(
-            "Output file %s exists already, use -f to overwrite." % xmlpath
-        )
-    write_xml(output_tok_path, xml)
+    if output_tok_path == "-":
+        write_xml(sys.stdout.buffer, xml)
+    else:
+        save_xml(output_tok_path, xml)
+    LOGGER.info("Wrote {}".format(output_tok_path))

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -387,9 +387,7 @@ def tokenize(**kwargs):
         LOGGER.setLevel("DEBUG")
         LOGGER.info(
             "Running readalongs tokenize(xmlfile={}, tokfile={}, force-overwrite={}).".format(
-                kwargs["xmlfile"],
-                kwargs["tokfile"],
-                kwargs["force_overwrite"],
+                kwargs["xmlfile"], kwargs["tokfile"], kwargs["force_overwrite"],
             )
         )
 

--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -113,11 +113,17 @@ def load_xml_with_encoding(input_path):
     return etree.parse(input_path)
 
 
+def write_xml(output_filelike, xml):
+    """ Write XML to already opened file-like object """
+    output_filelike.write(etree.tostring(xml, encoding="utf-8", xml_declaration=True))
+    output_filelike.write("\n".encode("utf-8"))
+
+
 def save_xml(output_path, xml):
+    """ Save XML to specific PATH """
     ensure_dirs(output_path)
     with open(output_path, "wb") as fout:
-        fout.write(etree.tostring(xml, encoding="utf-8", xml_declaration=True))
-        fout.write("\n".encode("utf-8"))
+        write_xml(fout, xml)
 
 
 def save_xml_zip(zip_path, output_path, xml):

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -44,7 +44,7 @@ class TestForceAlignment(unittest.TestCase):
         wav_path = os.path.join(self.data_dir, "ej-fra.m4a")
         # tempfh, temp_fn = create_input_xml(txt_path, text_language='git', save_temps="unit")
         tempfh, temp_fn = create_input_tei(
-            txt_path, text_language="fra", save_temps=None
+            input_file_name=txt_path, text_language="fra", save_temps=None
         )
         results = align_audio(temp_fn, wav_path, unit="w", save_temps=None)
 

--- a/test/test_prepare_cli.py
+++ b/test/test_prepare_cli.py
@@ -68,7 +68,7 @@ class TestPrepareCli(TestCase):
     def test_input_is_stdin(self):
         results = self.runner.invoke(prepare, "-l fra -", input="Ceci est un test.")
         # LOGGER.warning("Output: {}".format(results.output))
-        LOGGER.warning("Exception: {}".format(results.exception))
+        # LOGGER.warning("Exception: {}".format(results.exception))
         self.assertEqual(results.exit_code, 0)
         self.assertIn("<s>Ceci est un test", results.stdout)
         self.assertIn('<text xml:lang="fra">', results.stdout)
@@ -79,6 +79,7 @@ class TestPrepareCli(TestCase):
         results = self.runner.invoke(prepare, ["-l", "fra", input_file])
         self.assertEqual(results.exit_code, 0)
         self.assertRegex(results.stdout, "Wrote.*someinput[.]xml")
+        self.assertTrue(os.path.exists(os.path.join(self.tempdir, "someinput.xml")))
 
 
 if __name__ == "__main__":

--- a/test/test_prepare_cli.py
+++ b/test/test_prepare_cli.py
@@ -35,14 +35,17 @@ class TestPrepareCli(TestCase):
 
     def test_invoke_prepare(self):
         results = self.runner.invoke(
-            prepare, ["-l", "atj", "-d", self.empty_file, os.path.join(self.tempdir, "delme")]
+            prepare,
+            ["-l", "atj", "-d", self.empty_file, os.path.join(self.tempdir, "delme")],
         )
         self.assertEqual(results.exit_code, 0)
         self.assertRegex(results.stdout, "Running readalongs prepare")
         # print('Prepare.stdout: {}'.format(results.stdout))
 
     def test_no_lang(self):
-        results = self.runner.invoke(prepare, [self.empty_file, self.empty_file + ".xml"])
+        results = self.runner.invoke(
+            prepare, [self.empty_file, self.empty_file + ".xml"]
+        )
         self.assertNotEqual(results.exit_code, 0)
         self.assertRegex(results.stdout, "Missing.*language")
 
@@ -53,10 +56,12 @@ class TestPrepareCli(TestCase):
 
     def test_outputfile_exists(self):
         results = self.runner.invoke(
-            prepare, ["-l", "atj", self.empty_file, os.path.join(self.tempdir, "exists")]
+            prepare,
+            ["-l", "atj", self.empty_file, os.path.join(self.tempdir, "exists")],
         )
         results = self.runner.invoke(
-            prepare, ["-l", "atj", self.empty_file, os.path.join(self.tempdir, "exists")]
+            prepare,
+            ["-l", "atj", self.empty_file, os.path.join(self.tempdir, "exists")],
         )
         self.assertNotEqual(results.exit_code, 0)
         self.assertRegex(results.stdout, "exists.*overwrite")

--- a/test/test_tokenize_cli.py
+++ b/test/test_tokenize_cli.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+import io
+import os
+import sys
+import tempfile
+from shutil import copyfile
+from unittest import TestCase, main
+
+from readalongs.app import app
+from readalongs.cli import prepare, tokenize
+from readalongs.log import LOGGER
+
+
+class TestTokenizeCli(TestCase):
+    LOGGER.setLevel("DEBUG")
+    data_dir = os.path.join(os.path.dirname(__file__), "data")
+
+    def setUp(self):
+        app.logger.setLevel("DEBUG")
+        self.runner = app.test_cli_runner()
+        self.tempdirobj = tempfile.TemporaryDirectory(
+            prefix="test_tokenize_cli_tmpdir", dir="."
+        )
+        self.tempdir = self.tempdirobj.name
+        # Alternative tempdir code keeps it after running, for manual inspection:
+        # self.tempdir = tempfile.mkdtemp(prefix="test_tokenize_cli_tmpdir", dir=".")
+        # print('tmpdir={}'.format(self.tempdir))
+
+        self.xmlfile = os.path.join(self.tempdir, "fra.xml")
+        _ = self.runner.invoke(
+            prepare, ["-l", "fra", os.path.join(self.data_dir, "fra.txt"), self.xmlfile]
+        )
+
+    def tearDown(self):
+        self.tempdirobj.cleanup()
+
+    def test_invoke_tok(self):
+        results = self.runner.invoke(
+            tokenize, [self.xmlfile, os.path.join(self.tempdir, "delme")]
+        )
+        self.assertEqual(results.exit_code, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tempdir, "delme.xml")))
+
+    def test_generate_output_name(self):
+        results = self.runner.invoke(tokenize, self.xmlfile)
+        self.assertEqual(results.exit_code, 0)
+        self.assertTrue(os.path.exists(os.path.join(self.tempdir, "fra.tokenized.xml")))
+
+    def test_with_stdin(self):
+        with io.open(self.xmlfile) as f:
+            inputtext = f.read()
+        results = self.runner.invoke(tokenize, "-", input=inputtext)
+        self.assertEqual(results.exit_code, 0)
+        self.assertIn(
+            "<s><w>Ceci</w> <w>est</w> <w>une</w> <w>phrase</w>", results.output
+        )
+
+    def test_file_already_exists(self):
+        results = self.runner.invoke(tokenize, [self.xmlfile, self.xmlfile])
+        self.assertNotEqual(results.exit_code, 0)
+        self.assertIn("use -f to overwrite", results.output)
+
+    def test_bad_input(self):
+        results = self.runner.invoke(tokenize, "- -", input="this is not XML!")
+        self.assertNotEqual(results.exit_code, 0)
+        self.assertIn("Error parsing", results.output)
+        # LOGGER.warning("Output: {}".format(results.output))
+        # LOGGER.warning("Exception: {}".format(results.exception))
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_tokenize_cli.py
+++ b/test/test_tokenize_cli.py
@@ -43,7 +43,7 @@ class TestTokenizeCli(TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.tempdir, "delme.xml")))
 
     def test_generate_output_name(self):
-        results = self.runner.invoke(tokenize, self.xmlfile)
+        results = self.runner.invoke(tokenize, [self.xmlfile])
         self.assertEqual(results.exit_code, 0)
         self.assertTrue(os.path.exists(os.path.join(self.tempdir, "fra.tokenized.xml")))
 


### PR DESCRIPTION
Doing a PR for this work so I can document what I did and get some feedback.

The new command `readalongs tokenize` takes as input file an XML file created by `readalongs prepare`, runs it though the internal tokenizer, and outputs the tokenized file.

As per agreement at the last RAS dev meeting:
 - "-" means stdin/stdout, for both tokenize and prepare, so the commands can be used in pipes
 - if the output file name is not specified, it is auto-generated from the input file name
 - both commands add .xml to the file name if it doesn't already end in .xml
 - an existing output file is not overwritten by default, "-f" must be specified to do so