### PR TITLE
Fix readalongs prepare to insert paragraph and page breaks correctly

### DIFF
--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -288,7 +288,7 @@ def epub(**kwargs):
     context_settings=CONTEXT_SETTINGS,
     short_help="Prepare XML input to align from plain text.",
 )
-@click.argument("plaintextfile", type=click.File("rb"))
+@click.argument("plaintextfile", type=click.File("r"))
 @click.argument("xmlfile", type=click.Path(), required=False, default="")
 @click.option("-d", "--debug", is_flag=True, help="Add debugging messages to logger")
 @click.option(

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -5,6 +5,7 @@ source = readalongs
 omit = */readalongs/waveform2svg/*
 
 [report]
+precision = 2
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Don't complain if non-runnable code isn't run:

--- a/test/data/fra-prepared.xml
+++ b/test/data/fra-prepared.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
+<TEI>
+    <!-- To exclude any element from alignment, add the do-not-align="true" attribute to
+         it, e.g., <p do-not-align="true">...</p>, or
+         <s>Some text <foo do-not-align="true">do not align this</foo> more text</s> -->
+    <text xml:lang="fra">
+        <body>
+            <div type="page">
+                <p>
+                    <s>Ceci est une phrase en français. Ceci est une autre phrase.</s>
+                    <s>Et voici une deuxième ligne dans le même paragraphe.</s>
+                </p>
+                <p>
+                    <s>Un deuxième paragraphe précédé d&#x27;une ligne vide est ici. Avec deux phrases.</s>
+                </p>
+            </div>
+            <div type="page">
+                <p>
+                    <s>Et voici une deuxième page.</s>
+                </p>
+                <p>
+                    <s>Qui contient elle aussi deux paragraphes.</s>
+                </p>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/test/data/fra.txt
+++ b/test/data/fra.txt
@@ -1,4 +1,9 @@
 Ceci est une phrase en français. Ceci est une autre phrase.
-Et voici un deuxième paragraphe.
+Et voici une deuxième ligne dans le même paragraphe.
 
-Un quatrième paragraphe précédé d'un paragraphes vide est ici. Avec deux phrases.
+Un deuxième paragraphe précédé d'une ligne vide est ici. Avec deux phrases.
+
+
+Et voici une deuxième page.
+
+Qui contient elle aussi deux paragraphes.

--- a/test/test_prepare_cli.py
+++ b/test/test_prepare_cli.py
@@ -7,6 +7,7 @@ import tempfile
 from shutil import copyfile
 from unittest import TestCase, main
 
+from readalongs.align import create_input_tei
 from readalongs.app import app
 from readalongs.cli import prepare
 from readalongs.log import LOGGER
@@ -27,7 +28,7 @@ class TestPrepareCli(TestCase):
         # self.tempdir = tempfile.mkdtemp(prefix="test_prepare_cli_tmpdir", dir=".")
         # print("tmpdir={}".format(self.tempdir))
         self.empty_file = os.path.join(self.tempdir, "empty.txt")
-        with io.open(self.empty_file, "wb") as f:
+        with io.open(self.empty_file, "wb"):
             pass
 
     def tearDown(self):
@@ -106,6 +107,10 @@ class TestPrepareCli(TestCase):
         self.assertEqual(results.exit_code, 0)
         self.assertRegex(results.stdout, "Wrote.*someinput[.]xml")
         self.assertTrue(os.path.exists(os.path.join(self.tempdir, "someinput.xml")))
+
+    def test_create_input_tei_no_input(self):
+        with self.assertRaises(RuntimeError):
+            (fh, fname) = create_input_tei()
 
 
 if __name__ == "__main__":

--- a/test/test_prepare_cli.py
+++ b/test/test_prepare_cli.py
@@ -135,7 +135,7 @@ class TestPrepareCli(TestCase):
         self.assertEqual(
             linux_output,
             no_eol_output,
-            "leaving out the final newline should not affect prepare",
+            "An absent final newline should not affect prepare",
         )
 
         dos_file = os.path.join(self.tempdir, "dos_file")

--- a/test/test_prepare_cli.py
+++ b/test/test_prepare_cli.py
@@ -25,7 +25,7 @@ class TestPrepareCli(TestCase):
         self.tempdir = self.tempdirobj.name
         # Alternative tempdir code keeps it after running, for manual inspection:
         # self.tempdir = tempfile.mkdtemp(prefix="test_prepare_cli_tmpdir", dir=".")
-        # print('tmpdir={}'.format(self.tempdir))
+        # print("tmpdir={}".format(self.tempdir))
         self.empty_file = os.path.join(self.tempdir, "empty.txt")
         with io.open(self.empty_file, "wb") as f:
             pass
@@ -73,6 +73,21 @@ class TestPrepareCli(TestCase):
         )
         self.assertEqual(results.exit_code, 0)
         self.assertTrue(os.path.exists(xmlfile), "output xmlfile did not get created")
+
+    def test_output_correct(self):
+        input_file = os.path.join(self.data_dir, "fra.txt")
+        xml_file = os.path.join(self.tempdir, "fra.xml")
+        results = self.runner.invoke(prepare, ["-l", "fra", input_file, xml_file])
+        self.assertEqual(results.exit_code, 0)
+
+        ref_file = os.path.join(self.data_dir, "fra-prepared.xml")
+        with open(xml_file) as output_f, open(ref_file) as ref_f:
+            self.maxDiff = None
+            self.assertListEqual(
+                list(output_f),
+                list(ref_f),
+                f"output {xml_file} and reference {ref_file} differ.",
+            )
 
     def test_input_is_stdin(self):
         results = self.runner.invoke(prepare, "-l fra -", input="Ceci est un test.")


### PR DESCRIPTION
Turns out paragraph and page breaks processing was broken because I opened the input text file in mode "rb" instead of "r", which meant Python did not interpret newlines the way we expect it to.

Fixed the bug by changing how we open the input file in `prepare()` in `cli.py`, and added proper output validation in a test case so we catch the problem next time I break this by accident!