### PR TITLE
deps: bump networkx to 2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flask-socketio==4.3.2
 g2p>=0.5.*
 iso-639==0.4.5
 lxml==4.6.3
-networkx==2.3
+networkx==2.5
 numpy>=1.16.4
 panphon>=0.14
 soundswallower==0.1.1


### PR DESCRIPTION
The version specified in requirements.txt used to import `gcd` from `fractions` (it's actually in `math`), and thus, crashed on startup. networkx 2.5 includes this commit which fixes the problem: https://github.com/networkx/networkx/commit/b007158f3bfbcf77c52e4b39a81061914788ddf9#diff-21e03bb1d46583650bcad6e960f2ab8a5397395c986942b59314033e963dd3fc