### PR TITLE
fix: normalize key to NFKC in lexicon

### DIFF
--- a/readalongs/text/lexicon_g2p.py
+++ b/readalongs/text/lexicon_g2p.py
@@ -91,6 +91,7 @@ class LexiconG2P:
         len_text = len(text)
         text = text.strip("#").strip()
         text = text.upper()
+        text = normalize("NFKC", text)
         if text not in self.entries:
             raise KeyError(
                 "Word %s not found in lexicon %s" % (text, self.metadata["src"])


### PR DESCRIPTION
This might be a cursed commit.

For some reason that is not obvious to me, the CMU lexicon is normalized in NFKC form (why?????). That means that text that is looked up must _also_ be in NFKC form. I believe most other text flowing through the system is in NFD form? Either way, if the cmudict file _happens_ to gain non-ASCII keys — I don't know who would do such a thing 😉 — this commit will prevent it from crashing!