### PR TITLE
feat: Misc utility scripts that are peripheral to ReadAlongs Studio

### DIFF
--- a/misc-utils/README.md
+++ b/misc-utils/README.md
@@ -1,0 +1,31 @@
+## Misc Utils
+
+This directory contains miscellaneous utility scripts that are not part of the
+core of ReadAlongs Studio, but help with specific tasks in the perifery.
+
+Their Copyrights are different from the rest of the repo, and declared with
+license in each file, along with a documentation of the original provenance of
+the files.
+
+### `syll_parse.py`
+
+Syllabify a tokenized readalongs XML file, so that highlighting can happen
+syllable by syllable instead of word by word. This script should work reasonably
+well for languages in the latin script where syllabification follows the
+Sonority Sequencing Principle (SSP). For example, this works on Algonquin.
+
+Must be called manually after
+readalongs tokenize and before readalongs align or readalong g2p:
+
+    readalongs prepare -l my_lang file.txt file.xml
+    readalongs tokenize file.xml file-tok.xml
+    ./syll_parse.py file-tok.xml file-tok-syll.xml
+
+and then either:
+
+    readalongs align file-tok-syll.xml file.wav output
+
+or
+
+    readalongs g2p file-tok-syll.xml file-g2p.xml
+    readalongs align file-g2p.xml file.wav output

--- a/misc-utils/README.md
+++ b/misc-utils/README.md
@@ -31,3 +31,18 @@ or
 
     readalongs g2p file-tok-syll.xml file-g2p.xml
     readalongs align file-g2p.xml file.wav output
+
+### `non-caching-server.py`
+
+This script is intended to mitigate an issue with Mac's where the client might
+cache files and refuse to fetch them again even if they were modified on disk,
+even with a hard reload. This is an issue when, for example, testing a read
+along that you just created using
+
+    cd read-alongs-dir && python3 -m http.server
+
+If you modify the read along and want to reload it without having to restart the
+http server, on some OS's that works fine, but not on all OS's. If you encouter
+this problem, using this command instead:
+
+    cd read-alongs-dir && non-caching-server.py

--- a/misc-utils/README.md
+++ b/misc-utils/README.md
@@ -12,7 +12,9 @@ the files.
 Syllabify a tokenized readalongs XML file, so that highlighting can happen
 syllable by syllable instead of word by word. This script should work reasonably
 well for languages in the latin script where syllabification follows the
-Sonority Sequencing Principle (SSP). For example, this works on Algonquin.
+Sonority Sequencing Principle (SSP). For example, this works on Algonquin, and
+is currently setup to support Algonquin spelling. Modify the sets of letter by
+categories under "Sonority Hierarchy" to support other languages.
 
 Must be called manually after
 readalongs tokenize and before readalongs align or readalong g2p:

--- a/misc-utils/non-caching-server.py
+++ b/misc-utils/non-caching-server.py
@@ -1,5 +1,45 @@
 #!/usr/bin/env python3
 
+# This script is copied and modified from
+# https://github.com/python/cpython/blob/3.9/Lib/http/server.py
+# The original script is Copyright (c) Python Software Foundation and licensed
+# under the Python Software Foundation License Version 2.
+# See https://github.com/python/cpython/blob/main/LICENSE for the full details.
+
+# The modification made at National Research Council Canada are released under
+# the MIT License.
+
+# MIT License
+#
+# Copyright (c) 2021, National Research Council Canada (only for the NRC
+# modifications to this script)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Description of modifications by NRC
+# - Eddie Antonio Santos, 2021: extract the minimum http server code and modify
+#   it to disable client-side caching by systematically adding the header
+#       Cache-Control: no-store, max-age=0
+#   to all requests.
+#   This is to work around an issue on Mac computers where sometimes even a hard
+#   refresh will not fetch manually updated pages.
+
 import contextlib
 import os
 import urllib

--- a/misc-utils/non-caching-server.py
+++ b/misc-utils/non-caching-server.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import contextlib
+import os
+import urllib
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from http.server import test  # type: ignore
+from http import HTTPStatus
+
+
+class NonCachingHTTPRequestHandler(SimpleHTTPRequestHandler):
+    """
+    Same as SimpleHTTPRequestHandler, but instructs the browser to never cache!
+    """
+
+    def send_caching_headers(self):
+        """
+        See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#cacheability
+        """
+        self.send_header("Cache-Control", "no-store, max-age=0")
+
+    # copy-pasted from: https://github.com/python/cpython/blob/3.9/Lib/http/server.py
+    # changed:
+    #  - self.send_caching_headers
+    def send_head(self):
+        """Common code for GET and HEAD commands.
+        This sends the response code and MIME headers.
+        Return value is either a file object (which has to be copied
+        to the outputfile by the caller unless the command was HEAD,
+        and must be closed by the caller under all circumstances), or
+        None, in which case the caller has nothing further to do.
+        """
+        path = self.translate_path(self.path)
+        f = None
+        if os.path.isdir(path):
+            parts = urllib.parse.urlsplit(self.path)
+            if not parts.path.endswith('/'):
+                # redirect browser - doing basically what apache does
+                self.send_response(HTTPStatus.MOVED_PERMANENTLY)
+                new_parts = (parts[0], parts[1], parts[2] + '/',
+                             parts[3], parts[4])
+                new_url = urllib.parse.urlunsplit(new_parts)
+                self.send_header("Location", new_url)
+                self.end_headers()
+                return None
+            for index in "index.html", "index.htm":
+                index = os.path.join(path, index)
+                if os.path.exists(index):
+                    path = index
+                    break
+            else:
+                return self.list_directory(path)
+        ctype = self.guess_type(path)
+        # check for trailing "/" which should return 404. See Issue17324
+        # The test for this was added in test_httpserver.py
+        # However, some OS platforms accept a trailingSlash as a filename
+        # See discussion on python-dev and Issue34711 regarding
+        # parseing and rejection of filenames with a trailing slash
+        if path.endswith("/"):
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+        try:
+            f = open(path, 'rb')
+        except OSError:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+
+        try:
+            fs = os.fstat(f.fileno())
+
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-type", ctype)
+            self.send_header("Content-Length", str(fs[6]))
+            self.send_caching_headers()
+            self.end_headers()
+            return f
+        except:
+            f.close()
+            raise
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--bind', '-b', metavar='ADDRESS',
+                        help='Specify alternate bind address '
+                             '[default: all interfaces]')
+    parser.add_argument('--directory', '-d', default=os.getcwd(),
+                        help='Specify alternative directory '
+                        '[default:current directory]')
+    parser.add_argument('port', action='store',
+                        default=8000, type=int,
+                        nargs='?',
+                        help='Specify alternate port [default: 8000]')
+    args = parser.parse_args()
+    handler_class = partial(NonCachingHTTPRequestHandler,
+                            directory=args.directory)
+
+    # ensure dual-stack is not disabled; ref #38907
+    class DualStackServer(ThreadingHTTPServer):
+        def server_bind(self):
+            # suppress exception when protocol is IPv4
+            with contextlib.suppress(Exception):
+                self.socket.setsockopt(
+                    socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+            return super().server_bind()
+
+    test(
+        HandlerClass=handler_class,
+        ServerClass=DualStackServer,
+        port=args.port,
+        bind=args.bind,
+    )

--- a/misc-utils/non-caching-server.py
+++ b/misc-utils/non-caching-server.py
@@ -2,13 +2,65 @@
 
 # This script is copied and modified from
 # https://github.com/python/cpython/blob/3.9/Lib/http/server.py
-# The original script is Copyright (c) Python Software Foundation and licensed
-# under the Python Software Foundation License Version 2.
-# See https://github.com/python/cpython/blob/main/LICENSE for the full details.
+# The original script is Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+# 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020,
+# 2021 Python Software Foundation; All Rights Reserved
+# and licensed under the Python Software Foundation License Version 2
+# https://github.com/python/cpython/blob/main/LICENSE
+#
+# PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+# --------------------------------------------
+#
+# 1. This LICENSE AGREEMENT is between the Python Software Foundation
+# ("PSF"), and the Individual or Organization ("Licensee") accessing and
+# otherwise using this software ("Python") in source or binary form and
+# its associated documentation.
+#
+# 2. Subject to the terms and conditions of this License Agreement, PSF hereby
+# grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+# analyze, test, perform and/or display publicly, prepare derivative works,
+# distribute, and otherwise use Python alone or in any derivative version,
+# provided, however, that PSF's License Agreement and PSF's notice of copyright,
+# i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+# 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
+# All Rights Reserved" are retained in Python alone or in any derivative version
+# prepared by Licensee.
+#
+# 3. In the event Licensee prepares a derivative work that is based on
+# or incorporates Python or any part thereof, and wants to make
+# the derivative work available to others as provided herein, then
+# Licensee hereby agrees to include in any such work a brief summary of
+# the changes made to Python.
+#
+# 4. PSF is making Python available to Licensee on an "AS IS"
+# basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+# IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+# DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+# FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+# INFRINGE ANY THIRD PARTY RIGHTS.
+#
+# 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+# FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+# A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+# OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+#
+# 6. This License Agreement will automatically terminate upon a material
+# breach of its terms and conditions.
+#
+# 7. Nothing in this License Agreement shall be deemed to create any
+# relationship of agency, partnership, or joint venture between PSF and
+# Licensee.  This License Agreement does not grant permission to use PSF
+# trademarks or trade name in a trademark sense to endorse or promote
+# products or services of Licensee, or any third party.
+#
+# 8. By copying, installing or otherwise using Python, Licensee
+# agrees to be bound by the terms and conditions of this License
+# Agreement.
+
 
 # The modification made at National Research Council Canada are released under
 # the MIT License.
-
+#
 # MIT License
 #
 # Copyright (c) 2021, National Research Council Canada (only for the NRC
@@ -39,6 +91,15 @@
 #   to all requests.
 #   This is to work around an issue on Mac computers where sometimes even a hard
 #   refresh will not fetch manually updated pages.
+#
+#   Running this script in a root web site folder is equivalent to running
+#       python3 -m http.server
+#   in that folder, except that pages won't get cached.
+#
+# - Eric Joanis, 2021:
+#   - document the license and modification history of this script.
+#   - reformat with black and isort, and quiet flake8 warnings, so I can pass CI
+#     in the ReadAlongs/Studio repo.
 
 import contextlib
 import os

--- a/misc-utils/syll_parse.py
+++ b/misc-utils/syll_parse.py
@@ -48,11 +48,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-# Description of modifications by Fineen Davis at NRC
+# Description of modifications by NRC
 # - The original script by Estes&Hench provided the sonoropy() function
-# - the modifications at NRC handle loading a readalongs tokenized XML file,
-#   syllabifying each word, and writing the results back as a tokenized XML
-#   file for readalongs.
+# - Fineed Davis 2020:
+#   - adapt the script to Algonquin alphabet
+#   - handle loading a readalongs tokenized XML file, syllabifying each word,
+#     and writing the results back as a tokenized XML file for readalongs.
+# - Eric Joanis 2021:
+#   - add a basic command line interface
+#   - reformat whole file with black and isort and and quiet flake8 on sonoripy()
 
 
 import argparse

--- a/misc-utils/syll_parse.py
+++ b/misc-utils/syll_parse.py
@@ -1,0 +1,182 @@
+import codecs
+import itertools
+import unicodedata
+from lxml import etree
+import xml.etree.ElementTree
+from io import StringIO, BytesIO
+
+
+# -*- coding: utf-8 -*-
+# created at UC Berkeley 2015
+# Authors: Christopher Hench, Alex Estes
+
+'''This program syllabifies words based on the Sonority Sequencing Principle (SSP)'''
+
+def sonoripy(word):
+
+    def no_syll_no_vowel(ss):
+        # no syllable if no vowel
+        nss = []
+        front = ""
+        for i, syll in enumerate(ss):
+            # if following syllable doesn't have vowel,
+            # add it to the current one
+            if not any(char.lower() in vowels for char in syll):
+                if len(nss) == 0:
+                    front += syll
+                else:
+                    nss = nss[:-1] + [nss[-1] + syll]
+            else:
+                if len(nss) == 0:
+                    nss.append(front + syll)
+                else:
+                    nss.append(syll)
+
+        return nss
+
+    # SONORITY HIERARCHY, MODIFY FOR LANGUAGE BELOW
+    # categories can be collapsed into more general groups
+    vowels = 'aeiouyèùòìà'
+    approximates = ''
+    nasals = 'lmnrw'  # resonants and nasals
+    fricatives = 'zvsf'
+    affricates = ''
+    stops = 'bcdgtkpqxhj'  # rest of consonants
+
+    vowelcount = 0  # if vowel count is 1, syllable is automatically 1
+    sylset = []  # to collect letters and corresponding values
+    for letter in word.strip(".:;?!)('" + '"'):
+        if letter.lower() in vowels:
+            sylset.append((letter, 5))
+            vowelcount += 1  # to check for monosyllabic words
+        elif letter.lower() in approximates:
+            sylset.append((letter, 4))
+        elif letter.lower() in nasals:
+            sylset.append((letter, 3))
+        elif letter.lower() in fricatives:
+            sylset.append((letter, 2))
+        elif letter.lower() in affricates:
+            sylset.append((letter, 1))
+        elif letter.lower() in stops:
+            sylset.append((letter, 0))
+        else:
+            sylset.append((letter, 0))
+
+    # below actually divides the syllables
+    newsylset = []
+    if vowelcount <= 1:  # finalize word immediately if monosyllabic
+        newsylset.append(word)
+    else:
+        syllable = ''  # prepare empty syllable to build upon
+        for i, tup in enumerate(sylset):
+            if i == 0:  # if it's the first letter, append automatically
+                syllable += tup[0]
+            # lengths below are in order to not overshoot index
+            # when it looks beyond
+            else:
+                # add whatever is left at end of word, last letter
+                if i == len(sylset) - 1:
+                    syllable += tup[0]
+                    newsylset.append(syllable)
+
+                # MAIN ALGORITHM BELOW
+                # these cases DO NOT trigger syllable breaks
+                elif (i < len(sylset) - 1) and tup[1] < sylset[i + 1][1] and \
+                        tup[1] > sylset[i - 1][1]:
+                    syllable += tup[0]
+                elif (i < len(sylset) - 1) and tup[1] > sylset[i + 1][1] and \
+                        tup[1] < sylset[i - 1][1]:
+                    syllable += tup[0]
+                elif (i < len(sylset) - 1) and tup[1] > sylset[i + 1][1] and \
+                        tup[1] > sylset[i - 1][1]:
+                    syllable += tup[0]
+                elif (i < len(sylset) - 1) and tup[1] > sylset[i + 1][1] and \
+                        tup[1] == sylset[i - 1][1]:
+                    syllable += tup[0]
+                elif (i < len(sylset) - 1) and tup[1] == sylset[i + 1][1] and \
+                        tup[1] > sylset[i - 1][1]:
+                    syllable += tup[0]
+                elif (i < len(sylset) - 1) and tup[1] < sylset[i + 1][1] and \
+                        tup[1] == sylset[i - 1][1]:
+                    syllable += tup[0]
+
+                # these cases DO trigger syllable break
+                # if phoneme value is equal to value of preceding AND following
+                # phoneme
+                elif (i < len(sylset) - 1) and tup[1] == sylset[i + 1][1] and \
+                        tup[1] == sylset[i - 1][1]:
+                    syllable += tup[0]
+                    # append and break syllable BEFORE appending letter at
+                    # index in new syllable
+                    newsylset.append(syllable)
+                    syllable = ""
+
+                # if phoneme value is less than preceding AND following value
+                # (trough)
+                elif (i < len(sylset) - 1) and tup[1] < sylset[i + 1][1] and \
+                        tup[1] < sylset[i - 1][1]:
+                    # append and break syllable BEFORE appending letter at
+                    # index in new syllable
+                    newsylset.append(syllable)
+                    syllable = ""
+                    syllable += tup[0]
+
+                # if phoneme value is less than preceding value AND equal to
+                # following value
+                elif (i < len(sylset) - 1) and tup[1] == sylset[i + 1][1] and \
+                        tup[1] < sylset[i - 1][1]:
+                    syllable += tup[0]
+                    # append and break syllable BEFORE appending letter at
+                    # index in new syllable
+                    newsylset.append(syllable)
+                    syllable = ""
+                 
+
+        newsylset = no_syll_no_vowel(newsylset)
+
+    return (newsylset)
+
+
+# Load XML file and read it
+with open("/Volumes/Data/github_repos/Studio/word.xml", encoding="UTF-8") as fh:
+    equiv_text = unicodedata.normalize("NFC", fh.read())
+
+#root = etree.fromstring(equiv_text)
+root = etree.fromstring(equiv_text.encode("UTF-8"))
+
+
+# Find <w> elements in XML file
+for word in root.findall(".//w"):
+    del word.attrib["id"]
+    #get the text for each word
+    word_text = word.text
+    #remove text from word element
+    word.text = ''
+
+    word_sylls = sonoripy(word_text) #word_sylls is a list of lists []
+
+    #Adds sylls to <syll> elements which are children of the <w> element
+    #for syll in word_sylls:
+            # syll_element = etree.Element('syll')
+            # syll_element.text = syll
+            # word.append(syll_element)
+
+    #Adds sylls as <w> elements for alignment purposes
+    prev_word = word
+    prev_word.text = word_sylls.pop(0)
+
+    for syll in word_sylls:
+            next_word = etree.Element('w')
+            next_word.text = syll
+            prev_word.addnext(next_word)
+            prev_word = next_word
+
+
+        
+
+
+
+
+
+tree = etree.ElementTree(root)
+tree.write("/Volumes/Data/github_repos/Studio/word.xml", pretty_print=True)

--- a/misc-utils/syll_parse.py
+++ b/misc-utils/syll_parse.py
@@ -59,19 +59,19 @@ import argparse
 import codecs
 import itertools
 import unicodedata
-from lxml import etree
 import xml.etree.ElementTree
-from io import StringIO, BytesIO
+from io import BytesIO, StringIO
 
+from lxml import etree
 
 # -*- coding: utf-8 -*-
 # created at UC Berkeley 2015
 # Authors: Christopher Hench, Alex Estes
 
-'''This program syllabifies words based on the Sonority Sequencing Principle (SSP)'''
+"""This program syllabifies words based on the Sonority Sequencing Principle (SSP)"""
 
-def sonoripy(word):
 
+def sonoripy(word):  # noqa: C901
     def no_syll_no_vowel(ss):
         # no syllable if no vowel
         nss = []
@@ -94,12 +94,12 @@ def sonoripy(word):
 
     # SONORITY HIERARCHY, MODIFY FOR LANGUAGE BELOW
     # categories can be collapsed into more general groups
-    vowels = 'aeiouyèùòìà'
-    approximates = ''
-    nasals = 'lmnrw'  # resonants and nasals
-    fricatives = 'zvsf'
-    affricates = ''
-    stops = 'bcdgtkpqxhj'  # rest of consonants
+    vowels = "aeiouyèùòìà"
+    approximates = ""
+    nasals = "lmnrw"  # resonants and nasals
+    fricatives = "zvsf"
+    affricates = ""
+    stops = "bcdgtkpqxhj"  # rest of consonants
 
     vowelcount = 0  # if vowel count is 1, syllable is automatically 1
     sylset = []  # to collect letters and corresponding values
@@ -125,7 +125,7 @@ def sonoripy(word):
     if vowelcount <= 1:  # finalize word immediately if monosyllabic
         newsylset.append(word)
     else:
-        syllable = ''  # prepare empty syllable to build upon
+        syllable = ""  # prepare empty syllable to build upon
         for i, tup in enumerate(sylset):
             if i == 0:  # if it's the first letter, append automatically
                 syllable += tup[0]
@@ -139,30 +139,51 @@ def sonoripy(word):
 
                 # MAIN ALGORITHM BELOW
                 # these cases DO NOT trigger syllable breaks
-                elif (i < len(sylset) - 1) and tup[1] < sylset[i + 1][1] and \
-                        tup[1] > sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] < sylset[i + 1][1]
+                    and tup[1] > sylset[i - 1][1]
+                ):
                     syllable += tup[0]
-                elif (i < len(sylset) - 1) and tup[1] > sylset[i + 1][1] and \
-                        tup[1] < sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] > sylset[i + 1][1]
+                    and tup[1] < sylset[i - 1][1]
+                ):
                     syllable += tup[0]
-                elif (i < len(sylset) - 1) and tup[1] > sylset[i + 1][1] and \
-                        tup[1] > sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] > sylset[i + 1][1]
+                    and tup[1] > sylset[i - 1][1]
+                ):
                     syllable += tup[0]
-                elif (i < len(sylset) - 1) and tup[1] > sylset[i + 1][1] and \
-                        tup[1] == sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] > sylset[i + 1][1]
+                    and tup[1] == sylset[i - 1][1]
+                ):
                     syllable += tup[0]
-                elif (i < len(sylset) - 1) and tup[1] == sylset[i + 1][1] and \
-                        tup[1] > sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] == sylset[i + 1][1]
+                    and tup[1] > sylset[i - 1][1]
+                ):
                     syllable += tup[0]
-                elif (i < len(sylset) - 1) and tup[1] < sylset[i + 1][1] and \
-                        tup[1] == sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] < sylset[i + 1][1]
+                    and tup[1] == sylset[i - 1][1]
+                ):
                     syllable += tup[0]
 
                 # these cases DO trigger syllable break
                 # if phoneme value is equal to value of preceding AND following
                 # phoneme
-                elif (i < len(sylset) - 1) and tup[1] == sylset[i + 1][1] and \
-                        tup[1] == sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] == sylset[i + 1][1]
+                    and tup[1] == sylset[i - 1][1]
+                ):
                     syllable += tup[0]
                     # append and break syllable BEFORE appending letter at
                     # index in new syllable
@@ -171,8 +192,11 @@ def sonoripy(word):
 
                 # if phoneme value is less than preceding AND following value
                 # (trough)
-                elif (i < len(sylset) - 1) and tup[1] < sylset[i + 1][1] and \
-                        tup[1] < sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] < sylset[i + 1][1]
+                    and tup[1] < sylset[i - 1][1]
+                ):
                     # append and break syllable BEFORE appending letter at
                     # index in new syllable
                     newsylset.append(syllable)
@@ -181,31 +205,39 @@ def sonoripy(word):
 
                 # if phoneme value is less than preceding value AND equal to
                 # following value
-                elif (i < len(sylset) - 1) and tup[1] == sylset[i + 1][1] and \
-                        tup[1] < sylset[i - 1][1]:
+                elif (
+                    (i < len(sylset) - 1)
+                    and tup[1] == sylset[i + 1][1]
+                    and tup[1] < sylset[i - 1][1]
+                ):
                     syllable += tup[0]
                     # append and break syllable BEFORE appending letter at
                     # index in new syllable
                     newsylset.append(syllable)
                     syllable = ""
 
-
         newsylset = no_syll_no_vowel(newsylset)
 
-    return (newsylset)
+    return newsylset
 
 
 ### Modifications by Fineen Davis at National Research Council Canada
 
 # Basic argument parser added by Eric Joanis to support this usage:
 # syll_parse.py input.xml [output.xml]
-parser = argparse.ArgumentParser(description="syllabify a readalongs tokenized XML file")
+parser = argparse.ArgumentParser(
+    description="syllabify a readalongs tokenized XML file"
+)
 parser.add_argument(
-    "input_file", type=argparse.FileType("r"),
+    "input_file",
+    type=argparse.FileType("r"),
     help="Input tokenized XML file to syllabify (use - for stdin)",
 )
 parser.add_argument(
-    "output_file", type=str, default="-", nargs="?",
+    "output_file",
+    type=str,
+    default="-",
+    nargs="?",
     help="Output syllabified tokenized XML file (use - for stdout)",
 )
 args = parser.parse_args()
@@ -213,7 +245,7 @@ args = parser.parse_args()
 # Load XML file and read it
 equiv_text = unicodedata.normalize("NFC", args.input_file.read())
 
-#root = etree.fromstring(equiv_text)
+# root = etree.fromstring(equiv_text)
 root = etree.fromstring(equiv_text.encode("UTF-8"))
 
 
@@ -221,28 +253,28 @@ root = etree.fromstring(equiv_text.encode("UTF-8"))
 for word in root.findall(".//w"):
     if "id" in word.attrib:
         del word.attrib["id"]
-    #get the text for each word
+    # get the text for each word
     word_text = word.text
-    #remove text from word element
-    word.text = ''
+    # remove text from word element
+    word.text = ""
 
-    word_sylls = sonoripy(word_text) #word_sylls is a list of lists []
+    word_sylls = sonoripy(word_text)  # word_sylls is a list of lists []
 
-    #Adds sylls to <syll> elements which are children of the <w> element
-    #for syll in word_sylls:
-            # syll_element = etree.Element('syll')
-            # syll_element.text = syll
-            # word.append(syll_element)
+    # Adds sylls to <syll> elements which are children of the <w> element
+    # for syll in word_sylls:
+    # syll_element = etree.Element('syll')
+    # syll_element.text = syll
+    # word.append(syll_element)
 
-    #Adds sylls as <w> elements for alignment purposes
+    # Adds sylls as <w> elements for alignment purposes
     prev_word = word
     prev_word.text = word_sylls.pop(0)
 
     for syll in word_sylls:
-            next_word = etree.Element('w')
-            next_word.text = syll
-            prev_word.addnext(next_word)
-            prev_word = next_word
+        next_word = etree.Element("w")
+        next_word.text = syll
+        prev_word.addnext(next_word)
+        prev_word = next_word
 
 
 tree = etree.ElementTree(root)

--- a/misc-utils/syll_parse.py
+++ b/misc-utils/syll_parse.py
@@ -1,3 +1,61 @@
+#!/usr/bin/env python3
+
+# Original Copyright and License from https://github.com/alexestes/SonoriPy:
+#
+# MIT License
+#
+# Copyright (c) 2016 Alex Estes and Christopher Hench
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Copyright for modifications at NRC:
+#
+# MIT License
+#
+# Copyright (c) 2021 National Research Council Canada (NRC)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Description of modifications by Fineen Davis at NRC
+# - The original script by Estes&Hench provided the sonoropy() function
+# - the modifications at NRC handle loading a readalongs tokenized XML file,
+#   syllabifying each word, and writing the results back as a tokenized XML
+#   file for readalongs.
+
+
+import argparse
 import codecs
 import itertools
 import unicodedata
@@ -130,16 +188,30 @@ def sonoripy(word):
                     # index in new syllable
                     newsylset.append(syllable)
                     syllable = ""
-                 
+
 
         newsylset = no_syll_no_vowel(newsylset)
 
     return (newsylset)
 
 
+### Modifications by Fineen Davis at National Research Council Canada
+
+# Basic argument parser added by Eric Joanis to support this usage:
+# syll_parse.py input.xml [output.xml]
+parser = argparse.ArgumentParser(description="syllabify a readalongs tokenized XML file")
+parser.add_argument(
+    "input_file", type=argparse.FileType("r"),
+    help="Input tokenized XML file to syllabify (use - for stdin)",
+)
+parser.add_argument(
+    "output_file", type=str, default="-", nargs="?",
+    help="Output syllabified tokenized XML file (use - for stdout)",
+)
+args = parser.parse_args()
+
 # Load XML file and read it
-with open("/Volumes/Data/github_repos/Studio/word.xml", encoding="UTF-8") as fh:
-    equiv_text = unicodedata.normalize("NFC", fh.read())
+equiv_text = unicodedata.normalize("NFC", args.input_file.read())
 
 #root = etree.fromstring(equiv_text)
 root = etree.fromstring(equiv_text.encode("UTF-8"))
@@ -147,7 +219,8 @@ root = etree.fromstring(equiv_text.encode("UTF-8"))
 
 # Find <w> elements in XML file
 for word in root.findall(".//w"):
-    del word.attrib["id"]
+    if "id" in word.attrib:
+        del word.attrib["id"]
     #get the text for each word
     word_text = word.text
     #remove text from word element
@@ -172,11 +245,5 @@ for word in root.findall(".//w"):
             prev_word = next_word
 
 
-        
-
-
-
-
-
 tree = etree.ElementTree(root)
-tree.write("/Volumes/Data/github_repos/Studio/word.xml", pretty_print=True)
+tree.write(args.output_file, pretty_print=True)


### PR DESCRIPTION
For a while, I've been trying to figure out how to push `syll_parse.py` and `non-caching-server.py` to GitHub in a way that respects there respective original licenses yet makes them available for optional use with ReadAlongs/Studio. This is my proposed solution: a directory called `misc-utils` where each file has its own individual licensing information right in the source code, and a description of the NRC modifications. Plus a `README.md` that says what these are and what they are used for.

I want review from Eddie Antonio Santos, Fineen Davis, Aidan Pine and Pat Littell for this PR, to make sure we're all OK with the approach I'm taking here.

Deviation for our normal model is necessary because these files are derivatives of other OSS work.