### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,6 @@ RUN cd g2p && python3 -m pip install -e .
 # Install ReadAlong-Studio itself
 RUN python3 -m pip install -e .
 
-# Run the gui by default
-CMD gunicorn -k gevent -w 1 readalongs.app:app --bind 0.0.0.0:5000
+# Run the default gui
+#CMD gunicorn -k gevent -w 1 readalongs.app:app --bind 0.0.0.0:5000  #Disabled for now
+CMD python3 ./run.py


### PR DESCRIPTION
Commenting out starting up the GUI with gunicorn as this is causing issues. 

Example errors when using with gunicorn :
ERROR - Invalid session 0e60148254674e4eaa8d87c77a0e0925 (further occurrences of this error will be logged with level INFO)
[2021-08-03 18:40:17 +0000] [8] [CRITICAL] WORKER TIMEOUT (pid:161)
[2021-08-03 18:40:17 +0000] [161] [INFO] Worker exiting (pid: 161)
[2021-08-03 18:40:17 +0000] [164] [INFO] Booting worker with pid: 164


Using the default FLASH  dev webserver as this is more stable.