### PR TITLE
pylint all the test suites and improve style, docstring, etc.

### DIFF
--- a/test/basic_test_case.py
+++ b/test/basic_test_case.py
@@ -1,6 +1,8 @@
+"""Common base class for the ReadAlongs test suites"""
+
 import os
 import tempfile
-from unittest import TestCase, main
+from unittest import TestCase
 
 from readalongs.app import app
 from readalongs.log import LOGGER
@@ -20,6 +22,7 @@ class BasicTestCase(TestCase):
     keep_temp_dir_after_running = False
 
     def setUp(self):
+        """Create a temporary directory, self.tempdir, and a test runner, self.runner"""
         app.logger.setLevel("DEBUG")
         self.runner = app.test_cli_runner()
         tempdir_prefix = f"tmpdir_{type(self).__name__}_"
@@ -34,5 +37,6 @@ class BasicTestCase(TestCase):
             print("tmpdir={}".format(self.tempdir))
 
     def tearDown(self):
+        """Clean up the temporary directory"""
         if not self.keep_temp_dir_after_running:
             self.tempdirobj.cleanup()

--- a/test/run.py
+++ b/test/run.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
 
+"""
+Top-level runner for out test suites
+
+Invoke as
+   ./run.py [suite]
+where [suite] can be one of:
+   all: run everything, by searching the directory for all test suite files
+   prod: synonym for all
+   dev: run the standard development test suite - this is what we do in CI
+   e2e: run the end-to-end tests
+   other: run the other tests
+"""
+
 import os
 import sys
 from unittest import TestLoader, TestSuite, TextTestRunner
@@ -53,18 +66,22 @@ other_tests = [
 
 
 def run_tests(suite):
+    """Run the specified test suite"""
+
     if suite == "e2e":
         suite = TestSuite(e2e_tests)
     elif suite == "dev":
         suite = TestSuite(indices_tests + other_tests + e2e_tests)
-    elif suite == "prod" or suite == "all":
+    elif suite in ("prod", "all"):
         suite = loader.discover(os.path.dirname(__file__))
     elif suite == "other":
         suite = TestSuite(other_tests)
     else:
         LOGGER.error(
-            "Sorry, you need to select a Test Suite to run, like 'dev' or 'prod'"
+            "Sorry, you need to select a Test Suite to run, one of: "
+            "dev, all (or prod), e2e, other"
         )
+        sys.exit(1)
 
     runner = TextTestRunner(verbosity=3)
     return runner.run(suite)

--- a/test/test_anchors.py
+++ b/test/test_anchors.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+"""Unit testing for the anchors functionality in readalongs align"""
+
 import os
-import tempfile
-from unittest import TestCase, main
+from unittest import main
 
 from basic_test_case import BasicTestCase
 
@@ -10,7 +11,11 @@ from readalongs.align import align_audio
 
 
 class TestAnchors(BasicTestCase):
+    """Unit testing for the anchors functionality in readalongs align"""
+
     def test_anchors_inner_only(self):
+        """Test aligning with anchors only between existing text"""
+
         # ej-fra-anchors has anchors between words/sentences only
         results = align_audio(
             os.path.join(self.data_dir, "ej-fra-anchors.xml"),
@@ -29,6 +34,8 @@ class TestAnchors(BasicTestCase):
         self.assertGreaterEqual(words[22]["start"], 6.74)
 
     def test_anchors_outer_too(self):
+        """Test aligning with anchors defining DNA segments at start and end too"""
+
         # ej-fra-anchors2 also has anchors before the first word and after the last word
         save_temps_prefix = os.path.join(self.tempdir, "anchors2-temps")
         results = align_audio(

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -148,7 +148,12 @@ class TestAudio(BasicTestCase):
         write_audio_to_file(section, output_path)
         self.assertTrue(os.path.exists(output_path))
         reloaded_section = read_audio_from_file(output_path)
-        self.assertEqual(len(section), len(reloaded_section))
+        self.assertAlmostEqual(
+            len(section),
+            len(reloaded_section),
+            msg="reloaded audio file is more than 50ms shorter or longer",
+            delta=50,
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
+"""Test suite for various audio contents handling methods"""
+
 import os
-import tempfile
 from pathlib import Path
-from shutil import rmtree
 from subprocess import run
-from unittest import TestCase, main
+from unittest import main
 
 from basic_test_case import BasicTestCase
 
@@ -20,11 +20,9 @@ from readalongs.audio_utils import (
 from readalongs.log import LOGGER
 
 
-def segments_from_pairs(*pairs):
-    return list({"begin": b, "end": e} for b, e in pairs)
-
-
 class TestAudio(BasicTestCase):
+    """Test suite for various audio contents handling methods"""
+
     def setUp(self):
         super().setUp()
         self.audio_segment = read_audio_from_file(
@@ -35,6 +33,7 @@ class TestAudio(BasicTestCase):
         )
 
     def align(self, input_text_path, input_audio_path, output_path, flags):
+        """Wrapper for invoking readalongs align via subprocess.run"""
         args = [
             "readalongs",
             "align",
@@ -45,7 +44,7 @@ class TestAudio(BasicTestCase):
         LOGGER.info(
             f"Aligning {input_text_path} and {input_audio_path}, outputting to {output_path}"
         )
-        return run(args, capture_output=True)
+        return run(args, capture_output=True, check=False)
 
     def test_mute_section(self):
         """Should mute section of audio"""
@@ -134,12 +133,22 @@ class TestAudio(BasicTestCase):
         self.assertFalse("error" in str(log).lower())
 
     def test_extract_section(self):
+        """Unit test extract_section()"""
         self.assertEqual(len(extract_section(self.audio_segment, 1000, 2000)), 1000)
         self.assertEqual(len(extract_section(self.audio_segment, None, 500)), 500)
         self.assertEqual(
             len(extract_section(self.audio_segment, 1000, None)),
             len(self.audio_segment) - 1000,
         )
+
+    def test_write_audio_to_file(self):
+        """Mininal unit testing for write_audio_to_file"""
+        section = extract_section(self.audio_segment, 1000, 2000)
+        output_path = os.path.join(self.tempdir, "section_output.mp3")
+        write_audio_to_file(section, output_path)
+        self.assertTrue(os.path.exists(output_path))
+        reloaded_section = read_audio_from_file(output_path)
+        self.assertEqual(len(section), len(reloaded_section))
 
 
 if __name__ == "__main__":

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Test suite for loading the config.json configuration file for readalongs align"""
+
 import io
 import os
 from contextlib import redirect_stderr
@@ -11,6 +13,8 @@ from readalongs.text.add_elements_to_xml import add_images, add_supplementary_xm
 
 
 class TestConfig(TestCase):
+    """Test suite for loading the config.json configuration file for readalongs align"""
+
     @classmethod
     def setUpClass(cls):
         data_dir = os.path.join(os.path.dirname(__file__), "data")

--- a/test/test_dna_text.py
+++ b/test/test_dna_text.py
@@ -1,20 +1,22 @@
 #!/usr/bin/env python3
 
-import os
-import tempfile
-from unittest import TestCase, main
+"""Test handling of DNA text in tokenization"""
+
+from unittest import main
 
 from basic_test_case import BasicTestCase
 from lxml import etree
 
-from readalongs.app import app
-from readalongs.log import LOGGER
 from readalongs.text import tokenize_xml
 from readalongs.text.add_ids_to_xml import add_ids
 
 
 class TestDNAText(BasicTestCase):
+    """Test handling of DNA text in tokenization"""
+
     def test_tok_all_words(self):
+        """By default, all words should get tokenized"""
+
         txt = """<document xml:lang="fra">
 <s>Bonjour! Comment ça va?</s>
 <s>Voici une deuxième phrase.</s>
@@ -42,6 +44,8 @@ class TestDNAText(BasicTestCase):
         self.assertEqual(ids_as_txt, ref_with_ids)
 
     def test_tok_some_words(self):
+        """do-not-align text is excluded from tokenization"""
+
         txt = """<document xml:lang="fra">
 <p><s>Bonjour! Comment ça va?</s></p>
 <p do-not-align="true"><s>Bonjour! Comment ça va?</s></p>
@@ -73,6 +77,8 @@ class TestDNAText(BasicTestCase):
         self.assertEqual(ids_as_txt, ref_with_ids)
 
     def test_tok_div_p_s(self):
+        """Text inside a DNA div, p or s does not get tokenized"""
+
         txt = """<document xml:lang="fra">
 <div>
 <p> <s>Une phrase.</s> </p>
@@ -132,12 +138,16 @@ class TestDNAText(BasicTestCase):
         self.assertEqual(ids_as_txt, ref_with_ids)
 
     def test_dna_word(self):
+        """You can't have a DNA <w> element, that's reserved for tokens to align"""
+
         txt = """<s xml:lang="fra">Une <w do-not-align="true">exclude</w> phrase.</s>"""
         xml = etree.fromstring(txt)
         tokenized = tokenize_xml.tokenize_xml(xml)
         self.assertRaises(RuntimeError, add_ids, tokenized)
 
     def test_dna_word_nested(self):
+        """You also can't have a <w> element inside a DNA element"""
+
         txt = """<s xml:lang="fra">Une <foo do-not-align="true"><bar><w>exclude</w></bar></foo> phrase.</s>"""
         xml = etree.fromstring(txt)
         tokenized = tokenize_xml.tokenize_xml(xml)

--- a/test/test_dna_utils.py
+++ b/test/test_dna_utils.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Test suite for DNA segment manupulation methods"""
+
 from unittest import TestCase, main
 
 from readalongs.dna_utils import (
@@ -9,18 +11,23 @@ from readalongs.dna_utils import (
     segment_intersection,
     sort_and_join_dna_segments,
 )
-from readalongs.log import LOGGER
 
 
 def segments_from_pairs(*pairs):
+    """Pseudo constructor for a list of segment dicts with begin and end
+
+    segments should really be represented using an @dataclass, but that's for
+    a future refactoring task. For now, this gives me something easy to use for
+    unit testing.
+    """
     return list({"begin": b, "end": e} for b, e in pairs)
 
 
 class TestDNAUtils(TestCase):
-    """ Test suite for dna segment manipulation methods in dna_utils.py """
+    """Test suite for dna segment manipulation methods in dna_utils.py"""
 
     def test_sort_and_join_dna_segments(self):
-        """ Make sure sorting and joining DNA segments works. """
+        """Make sure sorting and joining DNA segments works."""
         self.assertEqual(
             sort_and_join_dna_segments(segments_from_pairs((1000, 1100), (1500, 2100))),
             segments_from_pairs((1000, 1100), (1500, 2100)),
@@ -39,8 +46,7 @@ class TestDNAUtils(TestCase):
         )
 
     def test_adjustment_calculation(self):
-        """ Try adjusting alignments of re-built audio
-        """
+        """Try adjusting alignments of re-built audio"""
         self.assertEqual(
             calculate_adjustment(1000, [{"begin": 1000, "end": 1100}]), 100
         )
@@ -65,8 +71,8 @@ class TestDNAUtils(TestCase):
             ),
             0,
         )
-        # When there are multiple dna segments, the timestamp to adjust has to shift with the adjustment
-        # e.g.:
+        # When there are multiple dna segments, the timestamp to adjust has to
+        # shift with the adjustment, e.g.:
         #    if DNA= [1000,2000)+[4000,5000)
         #    then 0-999 -> 0-999, 1000-2999 -> 2000-3999, and 3000+ -> 5000+
         for value, adjustment in [
@@ -86,8 +92,7 @@ class TestDNAUtils(TestCase):
             )
 
     def test_adjustment_correction(self):
-        """ Try correcting adjusted alignments of re-built audio
-        """
+        """Try correcting adjusted alignments of re-built audio"""
         self.assertEqual(
             correct_adjustments(950, 1125, [{"begin": 1000, "end": 1100}]), (950, 1000)
         )
@@ -105,6 +110,7 @@ class TestDNAUtils(TestCase):
         )
 
     def test_segment_intersection(self):
+        """Unit testing of segment_intersection()"""
         self.assertEqual(segment_intersection([], []), [])
         self.assertEqual(segment_intersection(segments_from_pairs((1, 3)), []), [])
         self.assertEqual(segment_intersection([], segments_from_pairs((1, 3))), [])
@@ -142,6 +148,7 @@ class TestDNAUtils(TestCase):
         )
 
     def test_dna_union(self):
+        """Unit testing of dna_union()"""
         self.assertEqual(
             dna_union(1000, 2000, 3000, [{"begin": 1100, "end": 1200}]),
             segments_from_pairs((0, 1000), (1100, 1200), (2000, 3000)),

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 
 """
-Test force-alignment with PocketSphinx FSG search from Python API
+Test force-alignment with SoundsSwallower FSG search from Python API
 """
 
 import os
-import tempfile
 import unittest
 
 from basic_test_case import BasicTestCase
@@ -18,7 +17,10 @@ from readalongs.text.util import load_txt, save_xml
 
 
 class TestForceAlignment(BasicTestCase):
-    def testAlign(self):
+    """Unit testing suite for forced-alignment with SoundsSwallower"""
+
+    def test_align(self):
+        """Basic alignment test case with XML input"""
         xml_path = os.path.join(self.data_dir, "ej-fra.xml")
         wav_path = os.path.join(self.data_dir, "ej-fra.m4a")
         results = align_audio(xml_path, wav_path, unit="w")
@@ -32,10 +34,11 @@ class TestForceAlignment(BasicTestCase):
         for w, xw in zip(words, xml_words):
             self.assertEqual(xw.attrib["id"], w["id"])
 
-    def testAlignText(self):
+    def test_align_text(self):
+        """Basic alignment test case with plain text input"""
         txt_path = os.path.join(self.data_dir, "ej-fra.txt")
         wav_path = os.path.join(self.data_dir, "ej-fra.m4a")
-        tempfh, temp_fn = create_input_tei(
+        _, temp_fn = create_input_tei(
             input_file_name=txt_path, text_language="fra", save_temps=None
         )
         results = align_audio(temp_fn, wav_path, unit="w", save_temps=None)
@@ -51,7 +54,10 @@ class TestForceAlignment(BasicTestCase):
 
 
 class TestXHTML(BasicTestCase):
-    def testConvert(self):
+    """Test converting the output to xhtml"""
+
+    def test_convert(self):
+        """Test converting the output to xhtml"""
         xml_path = os.path.join(self.data_dir, "ej-fra-converted.xml")
         xml = etree.parse(xml_path).getroot()
         convert_to_xhtml(xml)

--- a/test/test_indices.py
+++ b/test/test_indices.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Test suite for handling g2p indices"""
+
 from unittest import TestCase, main
 
 from g2p import make_g2p
@@ -10,7 +12,10 @@ from readalongs.log import LOGGER
 
 
 class TestIndices(TestCase):
+    """Test suite for handling g2p indices"""
+
     def test_basic_composition(self):
+        """Indices mapped through a two-step basic composition"""
         mapping = Mapping([{"in": "a", "out": "b"}])
         transducer = Transducer(mapping)
         tg = transducer("abba")
@@ -18,6 +23,7 @@ class TestIndices(TestCase):
         self.assertEqual(tg.edges, [(0, 0), (1, 1), (2, 2), (3, 3)])
 
     def test_tiered_composition(self):
+        """Indices mapped through a more complex, three-step composition"""
         transducer = make_g2p("dan", "eng-arpabet")
         tg = transducer("hej")
         self.assertEqual(tg.output_string, "HH EH Y ")

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 
+"""Test suite for misc stuff that don't need their own stand-alone suite"""
+
 from unittest import TestCase, main
 
-from test_audio import segments_from_pairs
+from test_dna_utils import segments_from_pairs
 
 from readalongs.align import split_silences
 from readalongs.text.util import parse_time
 
 
 class TestMisc(TestCase):
-    """ Testing miscellaneous stuff """
+    """Testing miscellaneous stuff"""
 
     def test_parse_time(self):
+        """Test readalongs.text.util.parse_time() with valid inputs"""
         for time_str, time_in_ms in (
             ("1234", 1234000),
             ("12s", 12000),
@@ -33,6 +36,7 @@ class TestMisc(TestCase):
             )
 
     def test_parse_time_errors(self):
+        """Test readalongs.text.util.parse_time() with invalid inputs"""
         for err_time_str in ("3.4.5 ms", ".", "", "asdf", " 0 h z ", "nm"):
             with self.assertRaises(
                 ValueError,
@@ -41,6 +45,7 @@ class TestMisc(TestCase):
                 _ = parse_time(err_time_str)
 
     def test_split_silences(self):
+        """Test readalongs.align.split_silences()"""
         dna = segments_from_pairs((1000, 2000), (5000, 5000))
         words = [
             {"id": i, "start": s, "end": e}

--- a/test/test_package_urls.py
+++ b/test/test_package_urls.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+from unittest import main
+
 import requests
 from basic_test_case import BasicTestCase
 
@@ -6,6 +10,11 @@ from readalongs.text.make_package import FONTS_BUNDLE_URL, JS_BUNDLE_URL
 
 class TestPackageURLs(BasicTestCase):
     def test_urls(self):
+        """Test the links that our package functionality depends on"""
         for endpoint in [FONTS_BUNDLE_URL, JS_BUNDLE_URL]:
             res = requests.get(endpoint)
             self.assertEqual(res.status_code, 200)
+
+
+if __name__ == "__name__":
+    main()

--- a/test/test_silence.py
+++ b/test/test_silence.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+"""Test suite for inserting silences into a readalong"""
+
 import os
 from unittest import main
 
@@ -9,7 +13,10 @@ from readalongs.cli import align
 
 
 class TestSilence(BasicTestCase):
+    """Test suite for inserting silences into a readalong"""
+
     def test_basic_silence_insertion(self):
+        """Basic usage of the silence feature in a readalong"""
         output = os.path.join(self.tempdir, "silence")
         # Run align from xml
         results = self.runner.invoke(

--- a/test/test_temp_file.py
+++ b/test/test_temp_file.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 
-"""
-Test PortableNamedTemporaryFile class
-"""
+"""Test PortableNamedTemporaryFile class"""
 
 import os
-import sys
 import unittest
 from tempfile import NamedTemporaryFile
 
@@ -14,37 +11,49 @@ from readalongs.portable_tempfile import PortableNamedTemporaryFile
 
 
 class TestTempFile(unittest.TestCase):
-    def testBasicFile(self):
-        f = open("delme_test_temp_file", mode="w")
+    """Test PortableNamedTemporaryFile class"""
+
+    def test_basic_file(self):
+        """Test basic file IO usage. This was more for me to learn file IO in Python..."""
+        f = open("delme_test_temp_file", mode="w", encoding="utf8")
         f.write("some text")
         f.close()
+        self.assertTrue(os.path.exists("delme_test_temp_file"))
         os.unlink("delme_test_temp_file")
+        self.assertFalse(os.path.exists("delme_test_temp_file"))
 
-    def testNTF(self):
+    def test_ntf(self):
+        """Regular usage of tempfile.NamedTemporaryFile from the standard library"""
         tf = NamedTemporaryFile(prefix="testtempfile_testNTF_", delete=False, mode="w")
         tf.write("Some text")
         # LOGGER.debug("tf.name {}".format(tf.name))
         tf.close()
-        readf = open(tf.name, mode="r")
+        readf = open(tf.name, mode="r", encoding="utf8")
         text = readf.readline()
         self.assertEqual(text, "Some text")
         readf.close()
         os.unlink(tf.name)
 
-    def testDeleteFalse(self):
+    def test_delete_false(self):
+        """PortableNamedTemporaryFile with delete=False behaves like tempfile.NamedTemporaryFile"""
         tf = PortableNamedTemporaryFile(
             prefix="testtempfile_testDeleteFalse_", delete=False, mode="w"
         )
         tf.write("Some text")
         tf.close()
         # LOGGER.info(tf.name)
-        readf = open(tf.name, mode="r")
+        readf = open(tf.name, mode="r", encoding="utf8")
         text = readf.readline()
         readf.close()
         self.assertEqual(text, "Some text")
         os.unlink(tf.name)
 
-    def testTypicalUsage(self):
+    def test_typical_usage(self):
+        """Typical usage of PortableNamedTemporaryFile, i.e., with delete=True
+
+        This is what PortableNamedTemporaryFile is all about, since tempfile.NamedTemporaryFile
+        with delete=True on Windows does not work like we might want it to.
+        """
         tf = PortableNamedTemporaryFile(
             prefix="testtempfile_testTypicalUsage_", delete=True, mode="w"
         )
@@ -52,12 +61,13 @@ class TestTempFile(unittest.TestCase):
         tf.write("Some text")
         tf.close()
         # LOGGER.info(tf.name)
-        readf = open(tf.name, mode="r")
+        readf = open(tf.name, mode="r", encoding="utf8")
         text = readf.readline()
         readf.close()
         self.assertEqual(text, "Some text")
 
-    def testUsingWith(self):
+    def test_using_with(self):
+        """In a with statement, the file will be deleted when the with exits"""
         with PortableNamedTemporaryFile(
             prefix="testtempfile_testUsingWith_", delete=True, mode="w"
         ) as tf:
@@ -65,12 +75,16 @@ class TestTempFile(unittest.TestCase):
             tf.write("Some text")
             tf.close()
             # LOGGER.info(tf.name)
-            readf = open(tf.name, mode="r")
+            filename = tf.name
+            readf = open(tf.name, mode="r", encoding="utf8")
             text = readf.readline()
             readf.close()
             self.assertEqual(text, "Some text")
+            self.assertTrue(os.path.exists(filename))
+        self.assertFalse(os.path.exists(filename))
 
-    def testSeek(self):
+    def test_seek(self):
+        """read/write operations should work on a PortableNamedTemporaryFile"""
         tf = PortableNamedTemporaryFile(
             prefix="testtempfile_testSeek_", delete=True, mode="w+"
         )

--- a/test/test_tokenize_cli.py
+++ b/test/test_tokenize_cli.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 
+"""Test suite for readalongs tokenize"""
+
 import io
 import os
-import sys
-import tempfile
-from shutil import copyfile
-from unittest import TestCase, main
+from unittest import main
 
 from basic_test_case import BasicTestCase
 
-from readalongs.app import app
 from readalongs.cli import prepare, tokenize
-from readalongs.log import LOGGER
+
+# from readalongs.log import LOGGER
 
 
 class TestTokenizeCli(BasicTestCase):
+    """Test suite for the readalongs tokenize CLI command"""
+
     def setUp(self):
+        """setUp() creates self.tempdir and prepares an XML file for use in other tests"""
         super().setUp()
 
         self.xmlfile = os.path.join(self.tempdir, "fra.xml")
@@ -24,6 +26,7 @@ class TestTokenizeCli(BasicTestCase):
         )
 
     def test_invoke_tok(self):
+        """Test a simple invocation of readalongs tokenize"""
         results = self.runner.invoke(
             tokenize, [self.xmlfile, os.path.join(self.tempdir, "delme")]
         )
@@ -31,12 +34,14 @@ class TestTokenizeCli(BasicTestCase):
         self.assertTrue(os.path.exists(os.path.join(self.tempdir, "delme.xml")))
 
     def test_generate_output_name(self):
+        """Test letting readalongs tokenize generate the output filename"""
         results = self.runner.invoke(tokenize, ["--debug", self.xmlfile])
         self.assertEqual(results.exit_code, 0)
         self.assertTrue(os.path.exists(os.path.join(self.tempdir, "fra.tokenized.xml")))
 
     def test_with_stdin(self):
-        with io.open(self.xmlfile) as f:
+        """Test readalongs reading from stdin and writing to stdout"""
+        with io.open(self.xmlfile, encoding="utf8") as f:
             inputtext = f.read()
         results = self.runner.invoke(tokenize, "-", input=inputtext)
         self.assertEqual(results.exit_code, 0)
@@ -45,11 +50,13 @@ class TestTokenizeCli(BasicTestCase):
         )
 
     def test_file_already_exists(self):
+        """Test that readalongs tokenize does not overwrite existing files by default"""
         results = self.runner.invoke(tokenize, [self.xmlfile, self.xmlfile])
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("use -f to overwrite", results.output)
 
     def test_bad_input(self):
+        """Test readalongs tokenize with invalid XML as input"""
         results = self.runner.invoke(tokenize, "- -", input="this is not XML!")
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("Error parsing", results.output)

--- a/test/test_tokenize_xml.py
+++ b/test/test_tokenize_xml.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Unit test suite for our XML tokenizer module"""
+
 from unittest import TestCase, main
 
 from lxml import etree
@@ -8,7 +10,10 @@ from readalongs.text import tokenize_xml
 
 
 class TestTokenizer(TestCase):
+    """Test the tokenize_xml function"""
+
     def test_simple(self):
+        """Simple tokenization test case"""
         txt = """<document>
 <s xml:lang="atj">Kwei! Tan e ici matisihin?</s>
 </document>
@@ -22,6 +27,7 @@ class TestTokenizer(TestCase):
         self.assertEqual(etree.tounicode(tokenized), ref)
 
     def test_mixed_lang(self):
+        """Tokenization test case with mixed languages"""
         txt = """<document>
 <s xml:lang="atj">Kwei! Tan e ici matisihin?</s>
 <s xml:lang="fra">Bonjour! Comment ça va?</s>
@@ -37,6 +43,7 @@ class TestTokenizer(TestCase):
         self.assertEqual(etree.tounicode(tokenized), ref)
 
     def test_mixed_words(self):
+        """Tokenization should be bypassed when <w> elements are already found in the input"""
         txt = """<document>
 <s xml:lang="atj">Kwei! (<w xml:lang="fra">Bonjour</w>!)</s>
 <s xml:lang="atj">Tan e ici matisihin?</s>
@@ -52,14 +59,17 @@ class TestTokenizer(TestCase):
         self.assertEqual(etree.tounicode(tokenized), ref)
 
     def test_comments(self):
+        """Make sure tokenize_xml ignores stuff inside comments"""
         txt = """<document>
-<s xml:lang="atj">Kwei! (<w xml:lang="fra">Bonjour</w>!)</s>
+<s xml:lang="atj">Kwei! (<subsent xml:lang="fra">Bonjour</subsent>!)</s>
+<!--<s>comments</s> <w>should</w> <p>be ignored</p>-->
 <s xml:lang="atj">Tan e ici matisihin?</s>
 </document>
 """
         ref = """<document>
-<s xml:lang="atj">Kwei! (<w xml:lang="fra">Bonjour</w>!)</s>
-<s xml:lang="atj">Tan e ici matisihin?</s>
+<s xml:lang="atj"><w>Kwei</w>! (<subsent xml:lang="fra"><w>Bonjour</w></subsent>!)</s>
+<!--<s>comments</s> <w>should</w> <p>be ignored</p>-->
+<s xml:lang="atj"><w>Tan</w> <w>e</w> <w>ici</w> <w>matisihin</w>?</s>
 </document>"""
         xml = etree.fromstring(txt)
         tokenized = tokenize_xml.tokenize_xml(xml)


### PR DESCRIPTION
Most changes are stylistic and adding doc, but systematically declaring the encoding when opening text files, as pylint recommends, is going to prevent potential future bugs. 