### PR TITLE
refactor(cli): replace --g2p-fallback option by -l with multiple languages

### DIFF
--- a/readalongs/util.py
+++ b/readalongs/util.py
@@ -58,28 +58,3 @@ def getLangs():
         # Sort LANGS so the -h messages list them alphabetically
         LANGS = sorted(LANGS)
         return LANGS, LANG_NAMES
-
-
-def parse_g2p_fallback(g2p_fallback_arg):
-    """Parse the g2p fallback command-line argument
-
-    Args:
-        g2p_fallback_arg (str): Optional; colon separated list of g2p fallback langs
-
-    Returns:
-        List[str]: the list of valid language codes in g2p_fallback_arg
-
-    Raises:
-        ValueError: if any language code in g2p_fallback_arg is not valid
-    """
-    if g2p_fallback_arg:
-        LANGS, _ = getLangs()
-        g2p_fallbacks = g2p_fallback_arg.split(":")
-        for lang in g2p_fallbacks:
-            if lang not in LANGS:
-                raise ValueError(
-                    f'g2p fallback lang "{lang}" is not valid; choose among {", ".join(LANGS)}'
-                )
-        return g2p_fallbacks
-    else:
-        return []

--- a/test/data/fra-prepared.xml
+++ b/test/data/fra-prepared.xml
@@ -3,7 +3,7 @@
     <!-- To exclude any element from alignment, add the do-not-align="true" attribute to
          it, e.g., <p do-not-align="true">...</p>, or
          <s>Some text <foo do-not-align="true">do not align this</foo> more text</s> -->
-    <text xml:lang="fra">
+    <text xml:lang="fra" fallback-langs="">
         <body>
             <div type="page">
                 <p>

--- a/test/test_align_cli.py
+++ b/test/test_align_cli.py
@@ -12,7 +12,7 @@ from basic_test_case import BasicTestCase
 from lxml.html import fromstring
 from sound_swallower_stub import SoundSwallowerStub
 
-from readalongs.cli import align
+from readalongs.cli import align, langs
 
 
 def write_file(filename: str, file_contents: str) -> str:
@@ -37,12 +37,8 @@ class TestAlignCli(BasicTestCase):
                 "-s",
                 "-o",
                 "vtt",
-                "-o",
-                "srt",
-                "-o",
-                "TextGrid",
-                "-o",
-                "eaf",
+                "-o",  # tests that we can use -o more than once
+                "srt:TextGrid:eaf",  # tests that we can give -o multiple values
                 "-l",
                 "fra",
                 "--config",
@@ -226,13 +222,14 @@ class TestAlignCli(BasicTestCase):
         self.assertNotEqual(results, 0)
         self.assertIn("Cannot write into output folder", results.output)
 
-    def test_align_help(self):
-        """Validates that readalongs align -h lists all in-langs that can map to eng-arpabet"""
-        results = self.runner.invoke(align, "-h")
+    def test_langs_cmd(self):
+        """Validates that readalongs langs lists all in-langs that can map to eng-arpabet"""
+        results = self.runner.invoke(langs)
         self.assertEqual(results.exit_code, 0)
-        self.assertIn("|crg-tmd|", results.stdout)
-        self.assertIn("|crg-dv|", results.stdout)
-        self.assertNotIn("|crg|", results.stdout)
+        self.assertIn("crg-tmd", results.stdout)
+        self.assertIn("crg-dv ", results.stdout)
+        self.assertNotIn("crg ", results.stdout)
+        self.assertNotIn("fn-unicode", results.stdout)
 
     def test_align_english(self):
         """Validates that LexiconG2P works for English language alignment"""

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -39,7 +39,7 @@ class TestForceAlignment(BasicTestCase):
         txt_path = os.path.join(self.data_dir, "ej-fra.txt")
         wav_path = os.path.join(self.data_dir, "ej-fra.m4a")
         _, temp_fn = create_input_tei(
-            input_file_name=txt_path, text_language="fra", save_temps=None
+            input_file_name=txt_path, text_languages=("fra",), save_temps=None
         )
         results = align_audio(temp_fn, wav_path, unit="w", save_temps=None)
 


### PR DESCRIPTION
as agreed on Nov 1, 2021 at the RA-S dev meeting, it's much more intuitive to
specify multiple languages with -l that having a separate option. To boot,
using an attribute mean the fallback languages can also be specified on any XML
node.

@roedoejet this CLI feature touches a lot of stuff, so I'd like its own independent review. I'll fast-forward merge it into `dev.cli` once you approve it.