### PR TITLE
perf: optimize the CLI, mostly by deferring expensive imports

### DIFF
--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -7,7 +7,7 @@
 #
 # In order to facilitate easy packaging and deployment of readalongs,
 # the make_package module takes a standard output directory from `readalongs align`
-# and outputs a single html file with assets enceded using base64 in-line in the html.
+# and outputs a single html file with assets encoded using base64 in-line in the html.
 #
 # Note, this is not the optimal deployment. The ReadAlongs-WebComponent is already very portable
 # and should be used directly as a webcomponent. However, in some situations a single-file
@@ -20,7 +20,6 @@ import os
 from base64 import b64encode
 from mimetypes import guess_type
 
-import requests
 from lxml import etree
 
 from readalongs.log import LOGGER
@@ -57,6 +56,8 @@ def encode_from_path(path: str) -> str:
     Returns:
         str: base64 string with data and mime signature
     """
+    import requests  # Defer expensive import
+
     with open(path, "rb") as f:
         path_bytes = f.read()
     if path.endswith("xml"):
@@ -106,6 +107,8 @@ def create_web_component_html(
     subheader="Subheader goes here",
     theme="light",
 ) -> str:
+    import requests  # Defer expensive import
+
     js = requests.get(JS_BUNDLE_URL)
     fonts = requests.get(FONTS_BUNDLE_URL)
     if js.status_code != 200:

--- a/readalongs/util.py
+++ b/readalongs/util.py
@@ -1,8 +1,20 @@
-import g2p.mappings.langs as g2p_langs
-from networkx import has_path
+import re
+from collections.abc import Iterable
+from itertools import tee
+
+import click
 
 LANGS = None
 LANG_NAMES = None
+
+
+def getLangsDeferred() -> Iterable:
+    """Lazilly get the list of language codes supported by g2p library
+
+    Yields an Iterable in such a way that the g2p database is only loaded when
+    the results are iterated over, rather than when this function is called.
+    """
+    yield from getLangs()[0]
 
 
 def getLangs():
@@ -21,6 +33,12 @@ def getLangs():
         # Cache the results so we only calculate this information once.
         return LANGS, LANG_NAMES
     else:
+        # Imports deferred to when the function is actually first called, because
+        # they load the g2p database and take a fair bit of time. And importing
+        # networkx is also quite expensive.
+        import g2p.mappings.langs as g2p_langs
+        from networkx import has_path
+
         # LANGS_AVAILABLE in g2p lists langs inferred by the directory structure of
         # g2p/mappings/langs, but in ReadAlongs, we need all input languages to any mappings.
         # E.g., for Michif, we need to allow crg-dv and crg-tmd, but not crg, which is what
@@ -58,3 +76,40 @@ def getLangs():
         # Sort LANGS so the -h messages list them alphabetically
         LANGS = sorted(LANGS)
         return LANGS, LANG_NAMES
+
+
+class JoinerCallback:
+    """Command-line parameter validation for multiple-value options.
+
+    The values can be repeated by giving the option multiple times on the
+    command line, or by joining them with strings matching joiner_re (colon or
+    comma, arbitrarily mixed, by default).
+
+    Matching is case insensitive.
+    """
+
+    def __init__(self, valid_values: Iterable, joiner_re=r"[,:]"):
+        self.valid_values = valid_values
+        self.joiner_re = joiner_re
+
+    # This signature meets the requirements of click.option's callback parameter:
+    def __call__(self, _ctx, _param, value_groups):
+        # Defer potentially expensive expansion of valid_values until we really need it.
+        self.valid_values, valid_values_iterator = tee(self.valid_values, 2)
+        lc_valid_values = [valid_value.lower() for valid_value in valid_values_iterator]
+        results = [
+            value.strip()
+            for value_group in value_groups
+            for value in re.split(self.joiner_re, value_group)
+        ]
+        for value in results:
+            if value.lower() not in lc_valid_values:
+                raise click.BadParameter(
+                    f"'{value}' is not one of {self.quoted_list(lc_valid_values)}."
+                )
+        return results
+
+    @staticmethod
+    def quoted_list(values):
+        """Display a list of values quoted, for easy reading in error messages."""
+        return ", ".join("'" + v + "'" for v in values)

--- a/readalongs/views.py
+++ b/readalongs/views.py
@@ -26,8 +26,6 @@ from readalongs.app import app, socketio
 from readalongs.log import LOGGER
 from readalongs.util import getLangs
 
-LANGS, LANG_NAMES = getLangs()
-
 ALLOWED_TEXT = ["txt", "xml", "docx"]
 ALLOWED_AUDIO = ["wav", "mp3"]
 ALLOWED_G2P = ["csv", "xlsx"]
@@ -142,10 +140,11 @@ def steps(step):
         session.clear()
         session["temp_dir"] = mkdtemp()
         temp_dir = session["temp_dir"]
+        langs, lang_names = getLangs()
         return render_template(
             "upload.html",
             uploaded=uploaded_files(temp_dir),
-            maps=[{"code": m, "name": LANG_NAMES[m]} for m in LANGS],
+            maps=[{"code": m, "name": lang_names[m]} for m in langs],
         )
     elif step == 2:
         return render_template("preview.html")

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -5,11 +5,13 @@
 import itertools
 from unittest import TestCase, main
 
+import click
 from lxml import etree
 from test_dna_utils import segments_from_pairs
 
 from readalongs.align import split_silences
 from readalongs.text.util import get_attrib_recursive, get_lang_attrib, parse_time
+from readalongs.util import JoinerCallback
 
 
 class TestMisc(TestCase):
@@ -150,6 +152,14 @@ class TestMisc(TestCase):
         # documentation, as it's what helped me figure out why I needed
         # element.xpath("./@"+attrib) instead of element.attrib[attrib]
         # get_attrib_recursive() --EJJ Nov 2021
+
+    def test_joiner_callback(self):
+        cb = JoinerCallback(iter("qwer"))  # iterable over four characters
+        self.assertEqual(cb(None, None, ["e:r"]), ["e", "r"])
+        self.assertEqual(cb(None, None, ["q,w"]), ["q", "w"])
+        with self.assertRaises(click.BadParameter):
+            cb(None, None, ["q:e", "a,w"])
+        self.assertEqual(cb(None, None, ["r:q", "w"]), ["r", "q", "w"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR speeds up readalongs, mostly by deferring expensive imports.

While there, added some docstrings and did additional relevant refactorings.

More review fun, @roedoejet, in case you didn't already have enough... :)

This PR speeds up the help messages quite a bit by deferring expensive imports to run them only when they're needed. 
Part of the code are cleaner too, but there's also some added complexity in other parts. I think it's a worthwhile trade off, I hope you agree!