### PR TITLE
docs: embed the list of languages right in the doc

### DIFF
--- a/docs/advanced-use.rst
+++ b/docs/advanced-use.rst
@@ -3,6 +3,8 @@
 Advanced topics
 ===============
 
+.. _adding-a-lang:
+
 Adding a new language to g2p
 ----------------------------
 

--- a/docs/cli-guide.rst
+++ b/docs/cli-guide.rst
@@ -184,6 +184,18 @@ A full command could be something like:
 - With other extensions, the beginning of the file is examined to
   automatically determine if it's XML or plain text.
 
+Supported languages
+~~~~~~~~~~~~~~~~~~~
+
+The ``readalongs langs`` command can be used to list all supported languages.
+
+Here is that list at the time of compiling this documentation:
+
+.. command-output:: readalongs langs
+
+See :ref:`adding-a-lang` for references on adding new languages to that list.
+
+
 The config.json file
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/cli-ref.rst
+++ b/docs/cli-ref.rst
@@ -6,13 +6,14 @@ Command line interface (CLI) reference
 This page contains the full reference documentation for each command in the CLI.
 See also :ref:`cli-guide` for guidelines on using the CLI.
 
-The ReadAlongs CLI has four key commands:
+The ReadAlongs CLI has five key commands:
 
 - :ref:`cli-align`: full alignment pipeline, from plain text or XML to a
   viewable readalong
 - :ref:`cli-prepare`: convert a plain text file into XML, for align
 - :ref:`cli-tokenize`: tokenize a prepared XML file
 - :ref:`cli-g2p`: g2p a tokenized XML file
+- :ref:`cli-langs`: list supported languages
 
 Each command can be run with ``-h`` or ``--help`` to display its usage manual,
 e.g., ``readalongs -h``, ``readalongs align --help``.
@@ -32,3 +33,7 @@ e.g., ``readalongs -h``, ``readalongs align --help``.
 .. _cli-g2p:
 .. click:: readalongs.cli:g2p
   :prog: readalongs g2p
+
+.. _cli-langs:
+.. click:: readalongs.cli:langs
+  :prog: readalongs langs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx_click.ext",
+    "sphinxcontrib.programoutput",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx
 guzzle_sphinx_theme
 sphinx-click
+sphinxcontrib-programoutput
 -r ../requirements.txt


### PR DESCRIPTION
Added a call to `readalongs langs` to embed its output right into the docs, for easiest access.

Is it reasonable to add this dependency on https://pypi.org/project/sphinxcontrib-programoutput/ / https://github.com/NextThought/sphinxcontrib-programoutput ? It seems well maintained.