### PR TITLE
Create an API for ReadAlongs/Studio from the click app.

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -389,7 +389,7 @@ def align_audio(  # noqa: C901
 
     aligned_segment_count = len(results["words"])
     token_count = len(results["tokenized"].xpath("//" + unit))
-    LOGGER.info(f"Number of words founds: {token_count}")
+    LOGGER.info(f"Number of words found: {token_count}")
     LOGGER.info(f"Number of aligned segments: {aligned_segment_count}")
 
     if aligned_segment_count == 0:

--- a/readalongs/api.py
+++ b/readalongs/api.py
@@ -9,10 +9,10 @@ def align(textfile, audiofile, output_base, language=None, **kwargs):
     """Run the "readalongs align" command from within a Python script.
 
     Args:
-        textfile (str): input text file (XML or plain text)
-        audiofile (str): input audio file (format supported by ffmpeg)
-        output_base (str): basename for output files
-        language (list[str]): Specify only of textfile is plain text;
+        textfile (str | Path): input text file (XML or plain text)
+        audiofile (str | Path): input audio file (format supported by ffmpeg)
+        output_base (str | Path): basename for output files
+        language (List[str]): Specify only of textfile is plain text;
             list of languages for g2p and g2p cascade
         save_temps (bool): Optional; whether to save temporary files
 

--- a/readalongs/api.py
+++ b/readalongs/api.py
@@ -1,11 +1,41 @@
 """
 api.py: API for calling readalongs CLI commands programmatically
+
+In this API, functions take the same arguments as on the readalongs
+command-line interface. The mapping between CLI options and API options is
+that the first long variant of an option described in "readalongs cmd -h" is
+the API option name, with hyphens replaced by undercores.
+
+Example from readalongs align -h:
+    option in CLI                       option in API
+    ================================    =================================
+    -l, --language, --languages TEXT    language=["l1", "l2"]
+    -f, --force-overwrite               force_overwrite=True
+    -c, --config PATH                   config=os.path.join("some", "path", "config.json")
+                                     OR config=pathlib.Path("/some/path/config.json")
+
+As shown above, file names can be constructed using os.path.join() or a Path
+class like pathlib.Path. Warning: don't just use "/some/path/config.json"
+because that is not portable accross platforms.
+
+Options that can be specified multiple times on the CLI should be provided as a
+list to the API methods.
+
+All API functions might raise the following exceptions:
+    click.BadParameter: when the is an error with the combination of parameters given
+    click.UsageError: when the alignment task requested cannot be completed
+    other exceptions: something else unexpected went wrong. Please report this as
+                      a bug at https://github.com/ReadAlongs/Studio/issues if
+                      you come accross such an exception and you believe the
+                      problem is not in your own code.
 """
 
+import click
 from readalongs import cli
+from readalongs.util import JoinerCallbackForClick, get_langs_deferred
 
 
-def align(textfile, audiofile, output_base, language=None, **kwargs):
+def align(textfile, audiofile, output_base, language=(), output_formats=(), **kwargs):
     """Run the "readalongs align" command from within a Python script.
 
     Args:
@@ -16,11 +46,9 @@ def align(textfile, audiofile, output_base, language=None, **kwargs):
             list of languages for g2p and g2p cascade
         save_temps (bool): Optional; whether to save temporary files
 
-    Run "readalongs align -h" or consult
-    https://readalong-studio.readthedocs.io/en/latest/cli-ref.html#readalongs-align
-    for the full list of arguments and their meaning. The name of an argument
-    here is the first long name of each argument there, with hyphens replaced
-    by underscores. All arguments not explicitly mentioned above are optional.
+        Run "readalongs align -h" or consult
+        https://readalong-studio.readthedocs.io/en/latest/cli-ref.html#readalongs-align
+        for the full list of arguments and their meaning.
 
     Raises:
         click.BadParameter: when the is an error with the combination of parameters given
@@ -28,13 +56,54 @@ def align(textfile, audiofile, output_base, language=None, **kwargs):
     """
 
     align_args = {param.name: param.default for param in cli.align.params}
+    if language:
+        language = JoinerCallbackForClick(get_langs_deferred())(value_groups=language)
+    if output_formats:
+        output_formats = JoinerCallbackForClick(cli.SUPPORTED_OUTPUT_FORMATS)(
+            value_groups=output_formats
+        )
+
     align_args.update(
         textfile=textfile,
         audiofile=audiofile,
         output_base=output_base,
         language=language,
+        output_formats=output_formats,
         **kwargs
     )
-    if align_args["output_formats"] is None:
-        align_args["output_formats"] = ()
+
     cli.align.callback(**align_args)
+
+
+def prepare(plaintextfile, xmlfile, language, **kwargs):
+    """Run the "readalongs prepare" command from withint a Python script.
+
+    Args:
+        plaintextfile (str | Path): input plain text file
+        xmlfile (str | Path): output XML file
+        language (List[str]): list of languages for g2p and g2p cascade
+
+        Run "readalongs prepare -h" or consult
+        https://readalong-studio.readthedocs.io/en/latest/cli-ref.html#readalongs-prepare
+        for the full list of arguments and their meaning.
+
+    Raises:
+        click.BadParameter: when the is an error with the combination of parameters given
+        click.UsageError: when the alignment task requested cannot be completed
+    """
+
+    prepare_args = {param.name: param.default for param in cli.prepare.params}
+    try:
+        with open(plaintextfile, "r", encoding="utf8") as plaintextfile_handle:
+            prepare_args.update(
+                plaintextfile=plaintextfile_handle,
+                xmlfile=xmlfile,
+                language=JoinerCallbackForClick(get_langs_deferred())(
+                    value_groups=language
+                ),
+                **kwargs
+            )
+            cli.prepare.callback(**prepare_args)
+    except OSError as e:
+        # e.g.: FileNotFoundError or PermissionError on open(plaintextfile) above
+        raise click.UsageError(e) from e

--- a/readalongs/api.py
+++ b/readalongs/api.py
@@ -1,0 +1,40 @@
+"""
+api.py: API for calling readalongs CLI commands programmatically
+"""
+
+from readalongs import cli
+
+
+def align(textfile, audiofile, output_base, language=None, **kwargs):
+    """Run the "readalongs align" command from within a Python script.
+
+    Args:
+        textfile (str): input text file (XML or plain text)
+        audiofile (str): input audio file (format supported by ffmpeg)
+        output_base (str): basename for output files
+        language (list[str]): Specify only of textfile is plain text;
+            list of languages for g2p and g2p cascade
+        save_temps (bool): Optional; whether to save temporary files
+
+    Run "readalongs align -h" or consult
+    https://readalong-studio.readthedocs.io/en/latest/cli-ref.html#readalongs-align
+    for the full list of arguments and their meaning. The name of an argument
+    here is the first long name of each argument there, with hyphens replaced
+    by underscores. All arguments not explicitly mentioned above are optional.
+
+    Raises:
+        click.BadParameter: when the is an error with the combination of parameters given
+        click.UsageError: when the alignment task requested cannot be completed
+    """
+
+    align_args = {param.name: param.default for param in cli.align.params}
+    align_args.update(
+        textfile=textfile,
+        audiofile=audiofile,
+        output_base=output_base,
+        language=language,
+        **kwargs
+    )
+    if align_args["output_formats"] is None:
+        align_args["output_formats"] = ()
+    cli.align.callback(**align_args)

--- a/readalongs/api.py
+++ b/readalongs/api.py
@@ -21,21 +21,32 @@ because that is not portable accross platforms.
 Options that can be specified multiple times on the CLI should be provided as a
 list to the API methods.
 
-All API functions might raise the following exceptions:
-    click.BadParameter: when the is an error with the combination of parameters given
-    click.UsageError: when the alignment task requested cannot be completed
-    other exceptions: something else unexpected went wrong. Please report this as
-                      a bug at https://github.com/ReadAlongs/Studio/issues if
-                      you come accross such an exception and you believe the
-                      problem is not in your own code.
+All API functions return the following tuple: (status, exception, log)
+ - status: 0 for OK, non-0 for Error
+ - exception: any exception caught, one of:
+    - click.BadParameter: when the is an error with the combination of parameters given
+    - click.UsageError: when the alignment task requested cannot be completed
+    - other exceptions: something else unexpected went wrong. Please report this as
+                        a bug at https://github.com/ReadAlongs/Studio/issues if
+                        you come accross such an exception and you believe the
+                        problem is not in your own code.
+ - log: any logging messages issued during execution
 """
 
+import io
+import logging
+from typing import Optional, Tuple
+
 import click
+
 from readalongs import cli
+from readalongs.log import LOGGER
 from readalongs.util import JoinerCallbackForClick, get_langs_deferred
 
 
-def align(textfile, audiofile, output_base, language=(), output_formats=(), **kwargs):
+def align(
+    textfile, audiofile, output_base, language=(), output_formats=(), **kwargs
+) -> Tuple[int, Optional[Exception], str]:
     """Run the "readalongs align" command from within a Python script.
 
     Args:
@@ -50,32 +61,47 @@ def align(textfile, audiofile, output_base, language=(), output_formats=(), **kw
         https://readalong-studio.readthedocs.io/en/latest/cli-ref.html#readalongs-align
         for the full list of arguments and their meaning.
 
-    Raises:
-        click.BadParameter: when the is an error with the combination of parameters given
-        click.UsageError: when the alignment task requested cannot be completed
+    Returns: (status, exception, log_text)
     """
 
-    align_args = {param.name: param.default for param in cli.align.params}
-    if language:
-        language = JoinerCallbackForClick(get_langs_deferred())(value_groups=language)
-    if output_formats:
-        output_formats = JoinerCallbackForClick(cli.SUPPORTED_OUTPUT_FORMATS)(
-            value_groups=output_formats
+    logging_stream = io.StringIO()
+    logging_handler = logging.StreamHandler(logging_stream)
+    try:
+        # Capture the logs
+        LOGGER.addHandler(logging_handler)
+
+        align_args = {param.name: param.default for param in cli.align.params}
+        if language:
+            language = JoinerCallbackForClick(get_langs_deferred())(
+                value_groups=language
+            )
+        if output_formats:
+            output_formats = JoinerCallbackForClick(cli.SUPPORTED_OUTPUT_FORMATS)(
+                value_groups=output_formats
+            )
+
+        align_args.update(
+            textfile=textfile,
+            audiofile=audiofile,
+            output_base=output_base,
+            language=language,
+            output_formats=output_formats,
+            **kwargs
         )
 
-    align_args.update(
-        textfile=textfile,
-        audiofile=audiofile,
-        output_base=output_base,
-        language=language,
-        output_formats=output_formats,
-        **kwargs
-    )
+        cli.align.callback(**align_args)
 
-    cli.align.callback(**align_args)
+        return (0, None, logging_stream.getvalue())
+    except Exception as e:
+        return (1, e, logging_stream.getvalue())
+    finally:
+        # Remove the log-capturing handler
+        LOGGER.removeHandler(logging_handler)
 
 
-def prepare(plaintextfile, xmlfile, language, **kwargs):
+def prepare(
+    plaintextfile, xmlfile, language, **kwargs
+) -> Tuple[int, Optional[Exception], str]:
     """Run the "readalongs prepare" command from withint a Python script.
 
     Args:
@@ -87,23 +113,34 @@ def prepare(plaintextfile, xmlfile, language, **kwargs):
         https://readalong-studio.readthedocs.io/en/latest/cli-ref.html#readalongs-prepare
         for the full list of arguments and their meaning.
 
-    Raises:
-        click.BadParameter: when the is an error with the combination of parameters given
-        click.UsageError: when the alignment task requested cannot be completed
+    Returns: (status, exception, log_text)
     """
 
-    prepare_args = {param.name: param.default for param in cli.prepare.params}
+    logging_stream = io.StringIO()
+    logging_handler = logging.StreamHandler(logging_stream)
     try:
-        with open(plaintextfile, "r", encoding="utf8") as plaintextfile_handle:
-            prepare_args.update(
-                plaintextfile=plaintextfile_handle,
-                xmlfile=xmlfile,
-                language=JoinerCallbackForClick(get_langs_deferred())(
-                    value_groups=language
-                ),
-                **kwargs
-            )
-            cli.prepare.callback(**prepare_args)
-    except OSError as e:
-        # e.g.: FileNotFoundError or PermissionError on open(plaintextfile) above
-        raise click.UsageError(e) from e
+        # Capture the logs
+        LOGGER.addHandler(logging_handler)
+
+        prepare_args = {param.name: param.default for param in cli.prepare.params}
+        try:
+            with open(plaintextfile, "r", encoding="utf8") as plaintextfile_handle:
+                prepare_args.update(
+                    plaintextfile=plaintextfile_handle,
+                    xmlfile=xmlfile,
+                    language=JoinerCallbackForClick(get_langs_deferred())(
+                        value_groups=language
+                    ),
+                    **kwargs
+                )
+                cli.prepare.callback(**prepare_args)
+        except OSError as e:
+            # e.g.: FileNotFoundError or PermissionError on open(plaintextfile) above
+            raise click.UsageError(e) from e
+
+        return (0, None, logging_stream.getvalue())
+    except Exception as e:
+        return (1, e, logging_stream.getvalue())
+    finally:
+        # Remove the log-capturing handler
+        LOGGER.removeHandler(logging_handler)

--- a/readalongs/api.py
+++ b/readalongs/api.py
@@ -3,7 +3,7 @@ api.py: API for calling readalongs CLI commands programmatically
 
 In this API, functions take the same arguments as on the readalongs
 command-line interface. The mapping between CLI options and API options is
-that the first long variant of an option described in "readalongs cmd -h" is
+that the first long variant of an option described in "readalongs <cmd> -h" is
 the API option name, with hyphens replaced by undercores.
 
 Example from readalongs align -h:

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -342,7 +342,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
                 "No input language specified for plain text input. "
                 "Please provide the -l/--language switch."
             )
-        languages = kwargs["language"]
+        languages = list(kwargs["language"])
         if not kwargs["lang_no_append_und"] and "und" not in languages:
             languages.append("und")
         plain_textfile = kwargs["textfile"]

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -451,7 +451,7 @@ def prepare(**kwargs):
                 out_file = out_file[:-4]
             out_file += ".xml"
 
-    languages = kwargs["language"]
+    languages = list(kwargs["language"])
     if not kwargs["lang_no_append_und"] and "und" not in languages:
         languages.append("und")
 

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -263,7 +263,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
     config_file = kwargs.get("config", None)
     config = None
     if config_file:
-        if config_file.endswith("json"):
+        if str(config_file).endswith("json"):
             try:
                 with open(config_file, encoding="utf8") as f:
                     config = json.load(f)
@@ -314,9 +314,9 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
 
     # Determine if the file is plain text or XML
     textfile_name = kwargs["textfile"]
-    if textfile_name.endswith(".xml"):
+    if str(textfile_name).endswith(".xml"):
         textfile_is_plaintext = False  # .xml is XML
-    elif textfile_name.endswith(".txt"):
+    elif str(textfile_name).endswith(".txt"):
         textfile_is_plaintext = True  # .txt is plain text
     else:
         # Files other than .xml or .txt are parsed using etree. If the parse is
@@ -447,7 +447,7 @@ def prepare(**kwargs):
     if not out_file:
         out_file = get_click_file_name(input_file)
         if out_file != "-":
-            if out_file.endswith(".txt"):
+            if str(out_file).endswith(".txt"):
                 out_file = out_file[:-4]
             out_file += ".xml"
 
@@ -463,7 +463,7 @@ def prepare(**kwargs):
             with io.open(filename, encoding="utf8") as f:
                 sys.stdout.write(f.read())
         else:
-            if not out_file.endswith(".xml"):
+            if not str(out_file).endswith(".xml"):
                 out_file += ".xml"
             if os.path.exists(out_file) and not kwargs["force_overwrite"]:
                 raise click.BadParameter(
@@ -516,12 +516,12 @@ def tokenize(**kwargs):
     if not kwargs["tokfile"]:
         output_path = get_click_file_name(input_file)
         if output_path != "-":
-            if output_path.endswith(".xml"):
+            if str(output_path).endswith(".xml"):
                 output_path = output_path[:-4]
             output_path += ".tokenized.xml"
     else:
         output_path = kwargs["tokfile"]
-        if not output_path.endswith(".xml") and not output_path == "-":
+        if not str(output_path).endswith(".xml") and not output_path == "-":
             output_path += ".xml"
 
     if os.path.exists(output_path) and not kwargs["force_overwrite"]:
@@ -620,14 +620,14 @@ def g2p(**kwargs):
     if not kwargs["g2pfile"]:
         output_path = get_click_file_name(input_file)
         if output_path != "-":
-            if output_path.endswith(".xml"):
+            if str(output_path).endswith(".xml"):
                 output_path = output_path[:-4]
-            if output_path.endswith(".tokenized"):
+            if str(output_path).endswith(".tokenized"):
                 output_path = output_path[: -len(".tokenized")]
             output_path += ".g2p.xml"
     else:
         output_path = kwargs["g2pfile"]
-        if not output_path.endswith(".xml") and not output_path == "-":
+        if not str(output_path).endswith(".xml") and not output_path == "-":
             output_path += ".xml"
 
     if os.path.exists(output_path) and not kwargs["force_overwrite"]:

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -352,7 +352,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
                 text_languages=languages,
                 save_temps=temp_base,
             )
-        except RuntimeError as e:
+        except (RuntimeError, OSError) as e:
             raise click.UsageError(e) from e
     else:
         xml_textfile = kwargs["textfile"]
@@ -475,7 +475,7 @@ def prepare(**kwargs):
                 text_languages=languages,
                 output_file=out_file,
             )
-    except RuntimeError as e:
+    except (RuntimeError, OSError) as e:
         raise click.UsageError(e) from e
 
     LOGGER.info("Wrote {}".format(out_file))

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -60,7 +60,7 @@ def encode_from_path(path: str) -> str:
 
     with open(path, "rb") as f:
         path_bytes = f.read()
-    if path.endswith("xml"):
+    if str(path).endswith("xml"):
         root = etree.fromstring(path_bytes)
         for img in root.xpath("//graphic"):
             url = img.get("url")
@@ -81,7 +81,7 @@ def encode_from_path(path: str) -> str:
         path_bytes = etree.tostring(root)
     b64 = str(b64encode(path_bytes), encoding="utf8")
     mime = guess_type(path)
-    if path.endswith(
+    if str(path).endswith(
         ".m4a"
     ):  # hack to get around guess_type choosing the wrong mime type for .m4a files
         # TODO: Check other popular audio formats, .wav, .mp3, .ogg, etc...

--- a/readalongs/util.py
+++ b/readalongs/util.py
@@ -107,7 +107,7 @@ class JoinerCallbackForClick:
         self.joiner_re = joiner_re
 
     # This signature meets the requirements of click.option's callback parameter:
-    def __call__(self, _ctx, _param, value_groups):
+    def __call__(self, _ctx=None, _param=None, value_groups=()):
         # Defer potentially expensive expansion of valid_values until we really need it.
         self.valid_values, valid_values_iterator = tee(self.valid_values, 2)
         lc_valid_values = [valid_value.lower() for valid_value in valid_values_iterator]

--- a/test/run.py
+++ b/test/run.py
@@ -19,6 +19,7 @@ from unittest import TestLoader, TestSuite, TextTestRunner
 
 from test_align_cli import TestAlignCli
 from test_anchors import TestAnchors
+from test_api import TestAlignApi
 from test_audio import TestAudio
 from test_config import TestConfig
 from test_dna_text import TestDNAText
@@ -57,6 +58,7 @@ other_tests = [
         TestPrepareCli,
         TestAudio,
         TestAlignCli,
+        TestAlignApi,
         TestG2pCli,
         TestMisc,
         TestSilence,

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -4,10 +4,11 @@
 Test suite for the API way to call align
 """
 
-from basic_test_case import BasicTestCase
 from pathlib import Path
-from sound_swallower_stub import SoundSwallowerStub
 from unittest import main
+
+from basic_test_case import BasicTestCase
+from sound_swallower_stub import SoundSwallowerStub
 
 import readalongs.api as api
 
@@ -16,14 +17,16 @@ class TestAlignApi(BasicTestCase):
     """Test suite for the API way to call align()"""
 
     def test_call_align(self):
+        # We deliberately pass pathlib.Path objects as input, to make sure the
+        # API accepts them too.
         data_dir = Path(self.data_dir)
         temp_dir = Path(self.tempdir)
         langs = ("fra",)  # make sure language can be an iterable, not just a list.
         with SoundSwallowerStub("t0b0d0p0s0w0:920:1520", "t0b0d0p0s1w0:1620:1690"):
             api.align(
-                str(data_dir / "ej-fra.txt"),
-                str(data_dir / "ej-fra.m4a"),
-                str(temp_dir / "output"),
+                data_dir / "ej-fra.txt",
+                data_dir / "ej-fra.m4a",
+                temp_dir / "output",
                 langs,
                 output_formats=["html"],
             )
@@ -39,7 +42,11 @@ class TestAlignApi(BasicTestCase):
                 (temp_dir / "output" / f).exists(),
                 f"successful alignment should have created {f}",
             )
-        self.assertEqual(list(langs), ["fra"], "Make sure the API call doesn't not modify my variables")
+        self.assertEqual(
+            list(langs),
+            ["fra"],
+            "Make sure the API call doesn't not modify my variables",
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -52,6 +52,10 @@ class TestAlignApi(BasicTestCase):
             "Make sure the API call doesn't not modify my variables",
         )
 
+        (status, exception, log) = api.align("", "", temp_dir / "errors")
+        self.assertNotEqual(status, 0)
+        self.assertFalse(exception is None)
+
     def test_call_prepare(self):
         data_dir = Path(self.data_dir)
         temp_dir = Path(self.tempdir)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -7,6 +7,7 @@ Test suite for the API way to call align
 from pathlib import Path
 from unittest import main
 
+import click
 from basic_test_case import BasicTestCase
 from sound_swallower_stub import SoundSwallowerStub
 
@@ -47,6 +48,23 @@ class TestAlignApi(BasicTestCase):
             ["fra"],
             "Make sure the API call doesn't not modify my variables",
         )
+
+    def test_call_prepare(self):
+        data_dir = Path(self.data_dir)
+        temp_dir = Path(self.tempdir)
+        api.prepare(data_dir / "ej-fra.txt", temp_dir / "prepared.xml", ("fra", "eng"))
+        with open(temp_dir / "prepared.xml") as f:
+            xml_text = f.read()
+            self.assertIn('xml:lang="fra" fallback-langs="eng,und"', xml_text)
+
+        with self.assertRaises(click.BadParameter):
+            api.prepare(
+                data_dir / "ej-fra.txt", temp_dir / "bad.xml", ("fra", "not-a-lang")
+            )
+        with self.assertRaises(click.UsageError):
+            api.prepare(
+                data_dir / "file-not-found.txt", temp_dir / "none.xml", ("fra",)
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -18,12 +18,13 @@ class TestAlignApi(BasicTestCase):
     def test_call_align(self):
         data_dir = Path(self.data_dir)
         temp_dir = Path(self.tempdir)
+        langs = ("fra",)  # make sure language can be an iterable, not just a list.
         with SoundSwallowerStub("t0b0d0p0s0w0:920:1520", "t0b0d0p0s1w0:1620:1690"):
             api.align(
                 str(data_dir / "ej-fra.txt"),
                 str(data_dir / "ej-fra.m4a"),
                 str(temp_dir / "output"),
-                ["fra"],
+                langs,
                 output_formats=["html"],
             )
         expected_output_files = (
@@ -38,6 +39,7 @@ class TestAlignApi(BasicTestCase):
                 (temp_dir / "output" / f).exists(),
                 f"successful alignment should have created {f}",
             )
+        self.assertEqual(list(langs), ["fra"], "Make sure the API call doesn't not modify my variables")
 
 
 if __name__ == "__main__":

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for the API way to call align
+"""
+
+from basic_test_case import BasicTestCase
+from pathlib import Path
+from sound_swallower_stub import SoundSwallowerStub
+from unittest import main
+
+import readalongs.api as api
+
+
+class TestAlignApi(BasicTestCase):
+    """Test suite for the API way to call align()"""
+
+    def test_call_align(self):
+        data_dir = Path(self.data_dir)
+        temp_dir = Path(self.tempdir)
+        with SoundSwallowerStub("t0b0d0p0s0w0:920:1520", "t0b0d0p0s1w0:1620:1690"):
+            api.align(
+                str(data_dir / "ej-fra.txt"),
+                str(data_dir / "ej-fra.m4a"),
+                str(temp_dir / "output"),
+                ["fra"],
+                output_formats=["html"],
+            )
+        expected_output_files = (
+            "output.smil",
+            "output.xml",
+            "output.m4a",
+            "index.html",
+            "output.html",
+        )
+        for f in expected_output_files:
+            self.assertTrue(
+                (temp_dir / "output" / f).exists(),
+                f"successful alignment should have created {f}",
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Immediate use case: ReadAlongsDesktop can now avoid repeating code already written by readalongs.cli, by calling the wrappers in readalongs.api.

The advantage of these wrappers over calling the underlying functions in readalongs.align etc is that all the error checking logic implemented in readalongs.cli is applied. The calls are equivalent to command line calls, but without going through a system call.