### PR TITLE
Dev.oo option: add hidden -oo option to control output orthography

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Run Tests
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ffmpeg
+        run: sudo apt-get -y install ffmpeg
+
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.7"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        run: |
+          # Install Python dependencies
+          pip install -r requirements.txt
+          # Install Studio itself
+          pip install -e .
+          # Legal check: make sure we don't have or introduce GPL dependencies
+          pip install pip-licenses
+          if pip-licenses | grep -v 'Artistic License' | grep -v LGPL | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
+          # Install testing requirements
+          pip install -r requirements.dev.txt
+          pip install coverage
+          pip install codecov
+          pip install gunicorn
+
+      - name: Run tests
+        run: |
+          gunicorn readalongs.app:app --bind 0.0.0.0:5000 --daemon
+          (cd test && coverage run run.py prod)
+
+      - name: coding style nit-picking, we want black compliance
+        run: find . -name \*.py | xargs black --check
+
+      - uses: codecov/codecov-action@v2
+        with:
+          directory: ./test
+          fail_ci_if_error: true # optional (default = false)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,14 +26,12 @@ jobs:
           if pip-licenses | grep -v 'Artistic License' | grep -v LGPL | grep GNU; then echo 'Please avoid introducing *GPL dependencies'; false; fi
           # Install testing requirements
           pip install -r requirements.dev.txt
-          pip install coverage
-          pip install codecov
-          pip install gunicorn
+          pip install coverage codecov gunicorn
 
       - name: Run tests
         run: |
           gunicorn readalongs.app:app --bind 0.0.0.0:5000 --daemon
-          (cd test && coverage run run.py prod)
+          (cd test && coverage run run.py prod && coverage xml)
 
       - name: coding style nit-picking, we want black compliance
         run: find . -name \*.py | xargs black --check

--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -163,6 +163,7 @@ def parse_and_prepare_input(
     config: dict,
     save_temps: Optional[str] = None,
     verbose_g2p_warnings: Optional[bool] = False,
+    output_orthography: str = "eng-arpabet",
 ) -> etree.ElementTree:
     """Parse XML input and run tokenization and G2P.
 
@@ -196,7 +197,11 @@ def parse_and_prepare_input(
     xml = add_ids(xml)
     if save_temps is not None:
         save_xml(save_temps + ".ids.xml", xml)
-    xml, valid = convert_xml(xml, verbose_warnings=verbose_g2p_warnings)
+    xml, valid = convert_xml(
+        xml,
+        verbose_warnings=verbose_g2p_warnings,
+        output_orthography=output_orthography,
+    )
     if save_temps is not None:
         save_xml(save_temps + ".g2p.xml", xml)
     if not valid:
@@ -506,6 +511,7 @@ def align_audio(
     save_temps: Optional[str] = None,
     verbose_g2p_warnings: Optional[bool] = False,
     debug_aligner: Optional[bool] = False,
+    output_orthography: str = "eng-arpabet",
 ):
     """Align an XML input file to an audio file.
 
@@ -538,6 +544,7 @@ def align_audio(
         config=config,
         verbose_g2p_warnings=verbose_g2p_warnings,
         save_temps=save_temps,
+        output_orthography=output_orthography,
     )
     results["tokenized"] = xml
 

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -189,7 +189,7 @@ def cli():
     "--output-orth",
     default="eng-arpabet",
     hidden=True,
-    help="Hidden option to disable to change output orthography",
+    help="Hidden option to change the output orthography",
 )
 @click.option(
     "-l",

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -185,6 +185,13 @@ def cli():
     help="Hidden option to disable to automatic appending of und (Undetermined) to -l",
 )
 @click.option(
+    "-oo",
+    "--output-orth",
+    default="eng-arpabet",
+    hidden=True,
+    help="Hidden option to disable to change output orthography",
+)
+@click.option(
     "-l",
     "--language",
     "--languages",
@@ -368,6 +375,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
             save_temps=temp_base,
             verbose_g2p_warnings=kwargs["debug_g2p"],
             debug_aligner=kwargs["debug_aligner"],
+            output_orthography=kwargs["output_orth"],
         )
     except RuntimeError as e:
         raise click.UsageError(e) from e

--- a/test/test_align_cli.py
+++ b/test/test_align_cli.py
@@ -491,6 +491,68 @@ class TestAlignCli(BasicTestCase):
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("is obsolete.", results.output)
 
+    def test_oo_option(self):
+        """Exercise the hidden -oo / --output-orth option"""
+        with SoundSwallowerStub("word:0:1"):
+            results = self.runner.invoke(
+                align,
+                [
+                    "-oo",
+                    "eng-arpabet",
+                    join(self.data_dir, "ej-fra.xml"),
+                    join(self.data_dir, "noise.mp3"),
+                    join(self.tempdir, "outdir9"),
+                ],
+            )
+        self.assertEqual(results.exit_code, 0)
+
+        with SoundSwallowerStub("word:0:1"):
+            results = self.runner.invoke(
+                align,
+                [
+                    "-oo",
+                    "not-an-alphabet",
+                    join(self.data_dir, "ej-fra.xml"),
+                    join(self.data_dir, "noise.mp3"),
+                    join(self.tempdir, "outdir10"),
+                ],
+            )
+        self.assertNotEqual(results.exit_code, 0)
+        self.assertIn("Could not g2p", results.output)
+        self.assertIn("not-an-alphabet", results.output)
+
+        with SoundSwallowerStub("word:0:1"):
+            results = self.runner.invoke(
+                align,
+                [
+                    "-oo",
+                    "dan-ipa",
+                    join(self.data_dir, "ej-fra.xml"),
+                    join(self.data_dir, "noise.mp3"),
+                    join(self.tempdir, "outdir11"),
+                ],
+            )
+        self.assertNotEqual(results.exit_code, 0)
+        self.assertIn("Could not g2p", results.output)
+        self.assertIn("no path", results.output)
+
+        with SoundSwallowerStub("word:0:1"):
+            results = self.runner.invoke(
+                align,
+                [
+                    "-oo",
+                    "dan-ipa",
+                    "-l",
+                    "eng",
+                    join(self.data_dir, "fra.txt"),
+                    join(self.data_dir, "noise.mp3"),
+                    join(self.tempdir, "outdir12"),
+                ],
+            )
+        self.assertNotEqual(results.exit_code, 0)
+        self.assertIn("Could not g2p", results.output)
+        self.assertIn('Cannot g2p "eng" to output orthography', results.output)
+
 
 if __name__ == "__main__":
     main()

--- a/test/test_g2p_cli.py
+++ b/test/test_g2p_cli.py
@@ -358,11 +358,11 @@ class TestG2pCli(BasicTestCase):
         """
         )
         with self.assertLogs(LOGGER, level="WARNING") as cm:
-            c_xml, valid = convert_xml(xml)
+            c_xml, valid = convert_xml(xml, verbose_warnings=True)
         self.assertFalse(valid)
         logger_output = "\n".join(cm.output)
-        self.assertIn('"foo": invalid language code', logger_output)
-        self.assertIn('"crx-syl": no path to "eng-arpabet"', logger_output)
+        self.assertIn('No language called: "foo"', logger_output)
+        self.assertIn('no path from "crx-syl"', logger_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This bringing in a hidden feature we created for the ras-evaluation done for the ComputEL and SIGUL papers.