### PR TITLE
style: move to black 22.3 and reformat everything accordingly

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -178,8 +178,7 @@ def parse_and_prepare_input(
         lxml.etree.ElementTree: Parsed and prepared XML
 
     Raises:
-        RuntimeError: If XML failed to parse
-"""
+        RuntimeError: If XML failed to parse"""
     # First do G2P
     try:
         xml = etree.parse(xml_path).getroot()

--- a/readalongs/audio_utils.py
+++ b/readalongs/audio_utils.py
@@ -12,8 +12,7 @@ from readalongs.log import LOGGER
 
 
 def join_section(audio: AudioSegment, audio_to_insert: AudioSegment, start: int):
-    """ Given two AudioSegments, insert the second into the first at start (ms)
-    """
+    """Given two AudioSegments, insert the second into the first at start (ms)"""
     try:
         return audio[:start] + audio_to_insert + audio[start:]
     except IndexError:
@@ -25,8 +24,7 @@ def join_section(audio: AudioSegment, audio_to_insert: AudioSegment, start: int)
 
 
 def remove_section(audio: AudioSegment, start: int, end: int) -> AudioSegment:
-    """ Given an AudioSement, remove the section between start (ms) and end (ms)
-    """
+    """Given an AudioSement, remove the section between start (ms) and end (ms)"""
     try:
         return audio[:start] + audio[end:]
     except IndexError:
@@ -38,7 +36,7 @@ def remove_section(audio: AudioSegment, start: int, end: int) -> AudioSegment:
 
 
 def mute_section(audio: AudioSegment, start: int, end: int) -> AudioSegment:
-    """ Given an AudioSegment, reduce the gain between a given interval by 120db.
+    """Given an AudioSegment, reduce the gain between a given interval by 120db.
         Effectively, make it silent.
 
     Args:
@@ -62,7 +60,7 @@ def mute_section(audio: AudioSegment, start: int, end: int) -> AudioSegment:
 def extract_section(
     audio: AudioSegment, start: Union[None, int], end: Union[None, int]
 ) -> AudioSegment:
-    """ Given an AudioSegment, extract and keep only the [start, end) interval
+    """Given an AudioSegment, extract and keep only the [start, end) interval
 
     Args:
         audio (AudioSegment): audio segment to extract a section from
@@ -89,7 +87,7 @@ def extract_section(
 
 
 def write_audio_to_file(audio: AudioSegment, path: str) -> None:
-    """ Write AudioSegment to file
+    """Write AudioSegment to file
 
     Args:
         audio (AudioSegment): audio segment to write
@@ -105,7 +103,7 @@ def write_audio_to_file(audio: AudioSegment, path: str) -> None:
 
 
 def read_audio_from_file(path: str) -> AudioSegment:
-    """ Read in AudioSegment from file
+    """Read in AudioSegment from file
 
     Args:
         path (str): Path to audiofile

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -466,7 +466,7 @@ def prepare(**kwargs):
     try:
         if out_file == "-":
             _, filename = create_input_tei(
-                input_file_handle=input_file, text_languages=languages,
+                input_file_handle=input_file, text_languages=languages
             )
             with io.open(filename, encoding="utf8") as f:
                 sys.stdout.write(f.read())
@@ -515,7 +515,7 @@ def tokenize(**kwargs):
         LOGGER.setLevel("DEBUG")
         LOGGER.info(
             "Running readalongs tokenize(xmlfile={}, tokfile={}, force-overwrite={}).".format(
-                kwargs["xmlfile"], kwargs["tokfile"], kwargs["force_overwrite"],
+                kwargs["xmlfile"], kwargs["tokfile"], kwargs["force_overwrite"]
             )
         )
 
@@ -619,7 +619,7 @@ def g2p(**kwargs):
         LOGGER.setLevel("DEBUG")
         LOGGER.info(
             "Running readalongs g2p(tokfile={}, g2pfile={}, force-overwrite={}).".format(
-                kwargs["tokfile"], kwargs["g2pfile"], kwargs["force_overwrite"],
+                kwargs["tokfile"], kwargs["g2pfile"], kwargs["force_overwrite"]
             )
         )
 
@@ -655,7 +655,7 @@ def g2p(**kwargs):
     xml = add_ids(xml)
 
     # Apply the g2p mappings.
-    xml, valid = convert_xml(xml, verbose_warnings=kwargs["debug_g2p"],)
+    xml, valid = convert_xml(xml, verbose_warnings=kwargs["debug_g2p"])
 
     if output_path == "-":
         write_xml(sys.stdout.buffer, xml)

--- a/readalongs/dna_utils.py
+++ b/readalongs/dna_utils.py
@@ -11,7 +11,7 @@ from typing import List, Tuple
 
 
 def sort_and_join_dna_segments(do_not_align_segments: List[dict]) -> List[dict]:
-    """ Give a list of DNA segments, sort them and join any overlapping ones """
+    """Give a list of DNA segments, sort them and join any overlapping ones"""
     results: List[dict] = []
     for seg in sorted(do_not_align_segments, key=lambda x: x["begin"]):
         if results and results[-1]["end"] >= seg["begin"]:
@@ -24,9 +24,9 @@ def sort_and_join_dna_segments(do_not_align_segments: List[dict]) -> List[dict]:
 def correct_adjustments(
     start: int, end: int, do_not_align_segments: List[dict]
 ) -> Tuple[int, int]:
-    """ Given the start and end of a segment (in ms) and a list of do-not-align segments,
-        If one of the do-not-align segments occurs inside one of the start-end range,
-        align the start or end with the do-not-align segment, whichever requires minimal change
+    """Given the start and end of a segment (in ms) and a list of do-not-align segments,
+    If one of the do-not-align segments occurs inside one of the start-end range,
+    align the start or end with the do-not-align segment, whichever requires minimal change
     """
     for seg in do_not_align_segments:
         if start < seg["begin"] and end > seg["end"]:
@@ -38,7 +38,7 @@ def correct_adjustments(
 
 
 def calculate_adjustment(timestamp: int, do_not_align_segments: List[dict]) -> int:
-    """ Given a time (in ms) and a list of do-not-align segments,
+    """Given a time (in ms) and a list of do-not-align segments,
         return the sum (ms) of the lengths of the do-not-align segments
         that start before the timestamp
 
@@ -58,7 +58,7 @@ def calculate_adjustment(timestamp: int, do_not_align_segments: List[dict]) -> i
 
 
 def segment_intersection(segments1: List[dict], segments2: List[dict]) -> List[dict]:
-    """ Return the intersection of two lists of segments
+    """Return the intersection of two lists of segments
 
     Precondition:
         segments1 and segments2 contain sorted, non-overlapping ranges
@@ -89,9 +89,9 @@ def segment_intersection(segments1: List[dict], segments2: List[dict]) -> List[d
 
 
 def dna_union(
-    start, end, audio_length: int, do_not_align_segments: List[dict],
+    start, end, audio_length: int, do_not_align_segments: List[dict]
 ) -> List[dict]:
-    """ Return the DNA list to include [start,end] and exclude do_not_align_segments
+    """Return the DNA list to include [start,end] and exclude do_not_align_segments
 
     Given time range [start, end] to keep, and a list of do-not-align-segments to
     exclude, calculate the equivalent do-not-align-segment list to keeping only

--- a/readalongs/log.py
+++ b/readalongs/log.py
@@ -6,12 +6,11 @@ import logging
 
 import coloredlogs
 
-FIELD_STYLES = dict(levelname=dict(color="green", bold=coloredlogs.CAN_USE_BOLD_FONT),)
+FIELD_STYLES = dict(levelname=dict(color="green", bold=coloredlogs.CAN_USE_BOLD_FONT))
 
 
 def setup_logger(name):
-    """Create logger and configure with cool colors!
-    """
+    """Create logger and configure with cool colors!"""
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(name)
 

--- a/readalongs/portable_tempfile.py
+++ b/readalongs/portable_tempfile.py
@@ -11,7 +11,7 @@ from tempfile import NamedTemporaryFile, template
 
 
 class _PortableNamedTemporaryFileWrapper:
-    """ Wrapper object around the real NamedTemporaryFile that forwards calls as needed
+    """Wrapper object around the real NamedTemporaryFile that forwards calls as needed
 
     The difference with NamedTemporaryFile is that we cleanup on exit and del, rather
     than on close.
@@ -54,7 +54,7 @@ class _PortableNamedTemporaryFileWrapper:
 def PortableNamedTemporaryFile(
     mode="w+b", suffix="", prefix=template, dir=None, delete=True
 ):
-    """ Portable named temporary file that works on Windows, Linux and Mac.
+    """Portable named temporary file that works on Windows, Linux and Mac.
 
     This class wraps tempfile.NamedTemporaryFile() with a portable behaviour that works
     on Windows, Linux and Mac as we need it to.

--- a/readalongs/run.py
+++ b/readalongs/run.py
@@ -22,8 +22,7 @@ from readalongs.app import app, socketio
 
 
 def run():
-    """ Run app using SocketIO
-    """
+    """Run app using SocketIO"""
     socketio.run(app)
 
 

--- a/readalongs/text/add_ids_to_xml.py
+++ b/readalongs/text/add_ids_to_xml.py
@@ -42,7 +42,7 @@ TAGS_TO_IGNORE = ["head", "teiHeader", "script"]
 
 
 def add_ids_aux(element: etree, ids: defaultdict, parent_id: str = "") -> defaultdict:
-    """ Add ids to xml element
+    """Add ids to xml element
 
     Args:
         element (etree): Element to add ids to

--- a/readalongs/text/convert_xml.py
+++ b/readalongs/text/convert_xml.py
@@ -53,7 +53,7 @@ from readalongs.util import get_langs
 
 
 def convert_words(  # noqa: C901
-    xml, word_unit="w", output_orthography="eng-arpabet", verbose_warnings=False,
+    xml, word_unit="w", output_orthography="eng-arpabet", verbose_warnings=False
 ):
     """Helper for convert_xml(), with the same Args and Return values, except
     xml is modified in place returned itself, instead of making a copy.
@@ -191,7 +191,7 @@ def convert_words(  # noqa: C901
 
 
 def convert_xml(
-    xml, word_unit="w", output_orthography="eng-arpabet", verbose_warnings=False,
+    xml, word_unit="w", output_orthography="eng-arpabet", verbose_warnings=False
 ):
     """Convert all the words in XML though g2p, putting the results in attribute ARPABET
 

--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -93,18 +93,18 @@ def load_xml_zip(zip_path, input_path):
 
 
 def load_xml_with_encoding(input_path):
-    """ etree.fromstring messes up on declared encodings """
+    """etree.fromstring messes up on declared encodings"""
     return etree.parse(input_path)
 
 
 def write_xml(output_filelike, xml):
-    """ Write XML to already opened file-like object """
+    """Write XML to already opened file-like object"""
     output_filelike.write(etree.tostring(xml, encoding="utf-8", xml_declaration=True))
     output_filelike.write("\n".encode("utf-8"))
 
 
 def save_xml(output_path, xml):
-    """ Save XML to specific PATH """
+    """Save XML to specific PATH"""
     ensure_dirs(output_path)
     with open(output_path, "wb") as fout:
         write_xml(fout, xml)
@@ -218,7 +218,7 @@ def unicode_normalize_xml(element):
 
 
 def parse_time(time_string: str) -> int:
-    """ Parse a time stamp in h/m/s(default)/ms or any combination of these units.
+    """Parse a time stamp in h/m/s(default)/ms or any combination of these units.
 
     Args:
         time_string (str): timestamp, e.g., "0.23s", "5.234" (implied s), "1234 ms",

--- a/readalongs/views.py
+++ b/readalongs/views.py
@@ -94,7 +94,7 @@ def update_session_config(**kwargs) -> dict:
 
 @app.route("/")
 def home():
-    """ Home View - go to Step 1 which is for uploading files """
+    """Home View - go to Step 1 which is for uploading files"""
     return redirect(url_for("steps", step=1))
 
 
@@ -148,7 +148,7 @@ def option_to_kwargs(option: str) -> str:
 
 @app.route("/step/<int:step>")
 def steps(step):
-    """ Go through steps """
+    """Go through steps"""
     if step == 1:
         session.clear()
         session["temp_dir"] = mkdtemp()

--- a/readalongs/waveform2svg/audio_util.py
+++ b/readalongs/waveform2svg/audio_util.py
@@ -29,7 +29,7 @@ SAMPLE_RATE = 16000
 
 
 def smooth(x, window_size=5):
-    """ Smooth the waveform to look... well, smooth """
+    """Smooth the waveform to look... well, smooth"""
     if window_size < 3:
         return x
     s = np.r_[2 * x[0] - x[window_size - 1 :: -1], x, 2 * x[-1] - x[-1:-window_size:-1]]
@@ -39,8 +39,8 @@ def smooth(x, window_size=5):
 
 
 def load_smil(input_path):
-    """ Get the bucketed max and min value from a sequence of WAV files as
-        expressed in a SMIL document """
+    """Get the bucketed max and min value from a sequence of WAV files as
+    expressed in a SMIL document"""
     xml = load_xml(input_path)
     dirname = os.path.dirname(input_path)
     data = None

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 pre-commit>=2.6.0
-black==19.10b0
+black~=22.0
 flake8>=3.8.3
 isort>=5.4.2
 mypy>=0.941

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -55,7 +55,7 @@ class TestConfig(TestCase):
         # bad xml raises lxml.etree.XMLSyntaxError
         with self.assertRaises(etree.XMLSyntaxError):
             new_xml = add_supplementary_xml(
-                self.xml, {"xml": [{"xpath": "//div[1]", "value": "bloop"}]},
+                self.xml, {"xml": [{"xpath": "//div[1]", "value": "bloop"}]}
             )
 
         # if xpath isn't valid, log warning

--- a/test/test_dna_utils.py
+++ b/test/test_dna_utils.py
@@ -129,7 +129,7 @@ class TestDNAUtils(TestCase):
         )
         self.assertEqual(
             segment_intersection(
-                segments_from_pairs((10, 30)), segments_from_pairs((19, 19)),
+                segments_from_pairs((10, 30)), segments_from_pairs((19, 19))
             ),
             segments_from_pairs((19, 19)),
         )

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -95,7 +95,7 @@ class TestForceAlignment(BasicTestCase):
                 writer.setframerate(16000)
                 writer.writeframes(b"\x00\x00")
             with self.assertRaises(RuntimeError):
-                _ = align_audio(xml_path, tf.name, unit="w",)
+                _ = align_audio(xml_path, tf.name, unit="w")
 
 
 class TestXHTML(BasicTestCase):
@@ -111,7 +111,7 @@ class TestXHTML(BasicTestCase):
             txt = load_txt(tf.name)
             self.maxDiff = None
             self.assertEqual(
-                txt, load_txt(os.path.join(self.data_dir, "ej-fra-converted.xhtml")),
+                txt, load_txt(os.path.join(self.data_dir, "ej-fra-converted.xhtml"))
             )
 
 

--- a/test/test_g2p_cli.py
+++ b/test/test_g2p_cli.py
@@ -188,7 +188,7 @@ class TestG2pCli(BasicTestCase):
 
         # Run with verbose output and look for the warning messages
         results = self.runner.invoke(
-            g2p, ["--debug-g2p", tok_file, g2p_file + "verbose"],
+            g2p, ["--debug-g2p", tok_file, g2p_file + "verbose"]
         )
         if self.show_invoke_output:
             print(


### PR DESCRIPTION
We were still using a beta version of black, 19.10b0. With the first
non-beta release, 22.1 (see https://black.readthedocs.io/en/latest/change_log.html),
black now has a stability policy (https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy)
promising that no formatting changes will happen between versions
starting with the same year. By using black~=22.0, we're declaring use
the formatting rules of the 2022 version of black, picking up the latest
in that series of releases.

Changes from the 19.10b0 to 22.3 that are visible in our code and
included in this commit:

 - The trailing comma is no longer allowed when a list fits on one line,
   it's only used when a list is broken on multiple lines, in which
   case it is required.
   So this is OK:

       foo = bar(
           arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11
       )

   But this will get reformatted to one arg per line becasue of the
   trailing comma:

       foo = bar(
           arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11,
       )

   Similarly, this will get reformatted to one arg per line because of
   the trailing comma:

       foo = bar(arg1, arg2,)

 - Docstrings no longer allow extra spaces.
   They are now strictly formatted like this:

       """Short function description

       Long description

       Returns:
           something
       """

   or

       """Short function description"""

   These will now get reformatted like above:

       """ Short function description

           Long description

           Returns:
               something
       """

   or

       """ Short function description """

   Version 19.10b0 of black would have accepted either and left them
   unchanged, but not 22.x.