### PR TITLE
feat: re-introduce the sub-word functionality in Studio

### DIFF
--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -69,6 +69,21 @@ def get_attrib_recursive(element, *attribs):
         return None
 
 
+def iterate_over_text(element):
+    """Iterate over all actual text contained with element and its sub-elements
+
+    Yields:
+        (language_code, text) pairs
+    """
+    lang = get_lang_attrib(element)
+    if element.text:
+        yield (lang, element.text)
+    for child in element:
+        yield from iterate_over_text(child)
+        if child.tail:
+            yield (lang, child.tail)
+
+
 def get_lang_attrib(element):
     """Return the xml:lang (in priority) or lang (fallback) attribute from element
     or its closest ancestor that has either, or None when neither is found.

--- a/test/data/patrickxtlan.xml
+++ b/test/data/patrickxtlan.xml
@@ -3,5 +3,6 @@
     <p>
         <s><w xml:lang="eng">Patrick</w><w xml:lang="kwk-umista">xtła̱n</w></s>
         <s><w xml:lang="und">Patrickxtła̱n</w></s>
+	<s><w>foo<syl xml:lang="eng">Patrick</syl>bar<syl xml:lang="kwk-umista">xtła̱n</syl>baz</w></s>
     </p>
 </TEI>

--- a/test/test_g2p_cli.py
+++ b/test/test_g2p_cli.py
@@ -23,7 +23,7 @@ def run_convert_xml(input_string):
 
 def two_xml_elements(xml_text):
     """Extract the opening part of the leading two XML elements in xml_text"""
-    return xml_text[: xml_text.find("<")]
+    return xml_text[: 1 + xml_text.find(">", 1 + xml_text.find(">"))]
 
 
 class TestG2pCli(BasicTestCase):
@@ -385,20 +385,25 @@ class TestG2pCli(BasicTestCase):
             two_xml_elements(converted_as_a_whole),
         )
 
-        moh_example_input_with_highlights = "<s xml:lang='moh'><w><span class='pronoun'>tati</span><span class='root'>atkèn:se</span><span class='aspect'>hkwe'</span></w></s>"
-        moh_example_input_merged = "<s xml:lang='moh'><w>tatiatkèn:sehkwe'</w></s>"
+        moh_eg_with_highlights = "<s xml:lang='moh'><w><span class='pronoun'>tati</span><span class='root'>atkèn:se</span><span class='aspect'>hkwe'</span></w></s>"
+        moh_eg_merged = "<s xml:lang='moh'><w>tatiatkèn:sehkwe'</w></s>"
+        self.assertEqual(two_xml_elements(moh_eg_merged), "<s xml:lang='moh'><w>")
         self.assertEqual(
-            two_xml_elements(run_convert_xml(moh_example_input_with_highlights)),
-            two_xml_elements(run_convert_xml(moh_example_input_merged)),
+            two_xml_elements(run_convert_xml(moh_eg_with_highlights)),
+            two_xml_elements(run_convert_xml(moh_eg_merged)),
         )
 
         moh_example_input_full = """
             <document xml:lang='moh'>
               <s>
-                <w><span class='pronoun'>tati</span><span class='root'>atkèn:se</span><span class='aspect'>hkwe'</span></w>
+                <w>
+                  <span class='pronoun'>tati</span>
+                  <span class='root'>atkèn:se</span>
+                  <span class='aspect'>hkwe'</span>
+                </w>
               </s>
             </document>"""
-        # print(run_convert_xml(moh_example_input_full))
+        _ = run_convert_xml(moh_example_input_full)
 
         example_with_fallback_lang = """
             <document xml:lang="fra" fallback-langs="eng"><s>


### PR DESCRIPTION
Words can now have sub-word structure. The text go g2p is collected from
all text in the <w> element and its sub-elements.

Sub-elements can have their own lang="lang_code" attribute. Like before,
we collect all text with the same language code and g2p it together,
then concatenate the results from g2p'ing the text in different
languages.

Note, however, that the fallback-langs attribute is only allowed on the
<w> elements and its parents, not on sub-word elements.