### PR TITLE
feat: clean up log handling and fix debug_aligner

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -236,18 +236,21 @@ def create_asr_config(
     asr_config.set_float("-pbeam", 1e-100)
     asr_config.set_float("-wbeam", 1e-80)
 
-    if not debug_aligner:
-        # With --debug-aligner, we display the SoundSwallower logs on screen, but
-        # otherwise we redirect them away from the terminal.
+    if debug_aligner:
+        # With --debug-aligner, we display the SoundSwallower logs on
+        # screen and set them to maximum strength
+        asr_config.set_string("-loglevel", "DEBUG")
+    else:
+        # Otherwise, we enable logging and direct it to a file if
+        # saving temporary files
         if save_temps is not None and (sys.platform not in ("win32", "cygwin")):
             # With --save-temps, we save the SoundSwallower logs to a file.
             # This is buggy on Windows, so we don't do it on Windows variants
+            # (NOTE: should be fixed in SoundSwallower 0.3 though)
             ss_log = save_temps + ".soundswallower.log"
-        else:
-            # Otherwise, we send the SoundSwallower logs to the bit bucket.
-            ss_log = os.devnull
-        asr_config.set_string("-logfn", ss_log)
-        asr_config.set_string("-loglevel", "DEBUG")
+            asr_config.set_string("-logfn", ss_log)
+            asr_config.set_string("-loglevel", "INFO")
+        # And otherwise the default is fine (only error messages are printed)
 
     # Set sampling rate based on audio (FIXME: this may cause problems
     # later on if it is too low)

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -89,6 +89,8 @@ class TestAudio(BasicTestCase):
             "pip install --force-reinstall --upgrade might be required "
             "if dependencies changed.",
         )
+        # Make sure ss logs are disabled
+        self.assertNotIn("Current configuration", process.stderr)
 
     def test_align_removed(self):
         """Try aligning section with removed audio"""
@@ -100,7 +102,7 @@ class TestAudio(BasicTestCase):
         # Align
         input_text_path = os.path.join(self.data_dir, "audio_sample.txt")
         input_audio_path = audio_output_path
-        flags = ["-l", "eng"]
+        flags = ["-l", "eng", "--debug-aligner"]
         output_path = os.path.join(self.tempdir, "output_removed")
         process = self.align(input_text_path, input_audio_path, output_path, flags)
         if process.returncode != 0:
@@ -114,6 +116,8 @@ class TestAudio(BasicTestCase):
             "pip install --force-reinstall --upgrade might be required "
             "if dependencies changed.",
         )
+        # Make sure ss logs are enabled
+        self.assertIn("Current configuration", process.stderr)
 
     def test_align_muted(self):
         """Try aligning section with muted audio"""

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -27,7 +27,7 @@ class TestForceAlignment(BasicTestCase):
         """Basic alignment test case with XML input"""
         xml_path = os.path.join(self.data_dir, "ej-fra.xml")
         wav_path = os.path.join(self.data_dir, "ej-fra.m4a")
-        results = align_audio(xml_path, wav_path, unit="w")
+        results = align_audio(xml_path, wav_path, unit="w", debug_aligner=True)
 
         # Verify that the same IDs are in the output
         converted_path = os.path.join(self.data_dir, "ej-fra-converted.xml")


### PR DESCRIPTION
Turns out that since -loglevel was implemented, debug_aligner has the unintended side effect of turning *off* most logging.  This changes the handling of logs to be more logical.  We don't send them to /dev/null now that we can control the log level (only errors are printed by default).  With save_temps we turn most logging on and send it to a file.  With debug_aligner we dump everything to the console.

In practice INFO and DEBUG are the same thing but that might not always be the case.