### PR TITLE
docs: Ask users to cite our SIGUL 2022 paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+message: >-
+  If you use this software, please cite our SIGUL 2022 paper using the
+  metadata below.
+title: ReadAlongs Studio
+url: https://github.com/ReadAlongs/Studio
+preferred-citation:
+  type: conference-paper
+  title: >-
+    ReadAlong Studio: Practical Zero-Shot Text-Speech Alignment for Indigenous
+    Language Audiobooks
+  authors:
+    - given-names: Patrick
+      family-names: Littell
+      email: Patrick.Littell@nrc-cnrc.gc.ca
+      affiliation: National Research Council Canada
+    - given-names: Eric
+      family-names: Joanis
+      email: Eric.Joanis@nrc-cnrc.gc.ca
+      affiliation: National Research Council Canada
+    - given-names: Aidan
+      family-names: Pine
+      email: Aidan.Pine@nrc-cnrc.gc.ca
+      affiliation: National Research Council Canada
+    - given-names: Marc
+      family-names: Tessier
+      email: Marc.Tessier@nrc-cnrc.gc.ca
+      affiliation: National Research Council Canada
+    - given-names: David
+      family-names: Huggins-Daines
+      email: dhdaines@gmail.com
+      affiliation: Independent Researcher
+    - given-names: Delasie
+      family-names: Torkornoo
+      email: delasie.torkornoo@carleton.ca
+      affiliation: Carleton University
+  collection-title: Proceedings of SIGUL2022 @LREC2022
+  pages: 23-32
+  year: 2022

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: >-
-  If you use this software, please cite our SIGUL 2022 paper using the
-  metadata below.
+  If you use this software in a project of yours and write about it, please
+  cite our SIGUL 2022 paper using the following citation data.
 title: ReadAlongs Studio
 url: https://github.com/ReadAlongs/Studio
 preferred-citation:
@@ -35,5 +35,12 @@ preferred-citation:
       email: delasie.torkornoo@carleton.ca
       affiliation: Carleton University
   collection-title: Proceedings of SIGUL2022 @LREC2022
-  pages: 23-32
+  start: 23
+  end: 32
   year: 2022
+  month: 6
+  publisher:
+    name: European Language Resources Assiciation (ELRA)
+  location:
+    name: Marseille
+  url: http://www.lrec-conf.org/proceedings/lrec2022/workshops/SIGUL/pdf/2022.sigul-1.4.pdf

--- a/README.md
+++ b/README.md
@@ -247,14 +247,19 @@ Project web page: [ReadAlong Studio: Application for Indigenous audiobooks and v
 
 ### Citation
 
-If you use this software, please cite our SIGUL 2022 paper:
+if you use this software in a project of yours and write about it, please cite
+us using the following:
 
 ```
 @inproceedings{Littell_ReadAlong_Studio_Practical_2022,
   author = {Littell, Patrick and Joanis, Eric and Pine, Aidan and Tessier, Marc and Huggins-Daines, David and Torkornoo, Delasie},
   booktitle = {Proceedings of SIGUL2022 @LREC2022},
   title = {{ReadAlong Studio: Practical Zero-Shot Text-Speech Alignment for Indigenous Language Audiobooks}},
-  year = {2022}
+  year = {2022},
+  month = {6},
+  pages = {23--32},
+  publisher = {European Language Resources Assiciation (ELRA)},
+  url = {http://www.lrec-conf.org/proceedings/lrec2022/workshops/SIGUL/pdf/2022.sigul-1.4.pdf}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,19 @@ Here is a partial list:
 
 Project web page: [ReadAlong Studio: Application for Indigenous audiobooks and videos project](https://nrc.canada.ca/en/research-development/research-collaboration/programs/readalong-studio-application-indigenous-audiobooks-videos-project)
 
+### Citation
+
+If you use this software, please cite our SIGUL 2022 paper:
+
+```
+@inproceedings{Littell_ReadAlong_Studio_Practical_2022,
+  author = {Littell, Patrick and Joanis, Eric and Pine, Aidan and Tessier, Marc and Huggins-Daines, David and Torkornoo, Delasie},
+  booktitle = {Proceedings of SIGUL2022 @LREC2022},
+  title = {{ReadAlong Studio: Practical Zero-Shot Text-Speech Alignment for Indigenous Language Audiobooks}},
+  year = {2022}
+}
+```
+
 ## License
 
-[MIT](LICENSE) © 2019-2021 David Huggins-Daines and National Research Council Canada
+[MIT](LICENSE) © 2019-2022 David Huggins-Daines and National Research Council Canada


### PR DESCRIPTION
 - Added a CITATION.cff with the info, which causes GitHub to display a
   "Cite this repository" button in the About section.
 - But for convenience and because it's normally where I would look,
   also add the BibTeX info in README.md

FIXES: #116