### PR TITLE
feat: add /convert_alignment endpoint

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -910,7 +910,7 @@ def save_readalong(
     smil = make_smil(
         os.path.basename(tokenized_xml_path),
         os.path.basename(audio_path),
-        align_results,
+        align_results["words"],
     )
     save_txt(smil_path, smil)
 

--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -716,24 +716,30 @@ def align_audio(
     return results
 
 
+def get_audio_duration(audiofile: str) -> float:
+    """Return the duration of audiofile in seconds"""
+    audio = read_audio_from_file(audiofile)
+    return audio.frame_count() / audio.frame_rate
+
+
 def save_label_files(
-    align_results: Dict[str, List],
-    audiofile: str,
+    words: List[dict],
+    tokenized_xml: etree.ElementTree,
+    duration: float,
     output_base: str,
     output_formats: Iterable[str],
 ):
     """Save label (TextGrid and/or EAF) files.
 
     Args:
-        align_results (Dict[str, List]): results of alignment
-        audiofile (str): Path to input audio
+        words: list of words with "id", "start" and "end"
+        tokenized_xml: tokenized or g2p'd parsed XML object
+        duration: length of the audio in seconds
         output_base (str): Base path for output files
         output_formats (Iterable[str]): List of output formats
     """
-    audio = read_audio_from_file(audiofile)
-    duration = audio.frame_count() / audio.frame_rate
-    words, sentences = get_words_and_sentences(align_results)
-    textgrid = write_to_text_grid(words, sentences, duration)
+    textual_words, sentences = get_textual_words_and_sentences(words, tokenized_xml)
+    textgrid = create_text_grid(textual_words, sentences, duration)
 
     if "textgrid" in output_formats:
         textgrid.to_file(output_base + ".TextGrid")
@@ -743,18 +749,22 @@ def save_label_files(
 
 
 def save_subtitles(
-    align_results: Dict[str, List], output_base: str, output_formats=Iterable[str]
+    words: List[dict],
+    tokenized_xml: etree.ElementTree,
+    output_base: str,
+    output_formats=Iterable[str],
 ):
     """Save subtitle (SRT and/or VTT) files.
 
     Args:
-        align_results (Dict[str, List]): results of alignment
+        words: list of words with "id", "start" and "end"
+        tokenized_xml: tokenized or g2p'd parsed XML object
         output_base (str): Base path for output files
         output_formats (Iterable[str]): List of output formats
     """
-    words, sentences = get_words_and_sentences(align_results)
+    textual_words, sentences = get_textual_words_and_sentences(words, tokenized_xml)
     cc_sentences = write_to_subtitles(sentences)
-    cc_words = write_to_subtitles(words)
+    cc_words = write_to_subtitles(textual_words)
 
     if "srt" in output_formats:
         cc_sentences.save_as_srt(output_base + "_sentences.srt")
@@ -880,8 +890,9 @@ def save_readalong(
     # Create textgrid object if outputting to TextGrid or eaf
     if "textgrid" in output_formats or "eaf" in output_formats:
         save_label_files(
-            align_results=align_results,
-            audiofile=audiofile,
+            words=align_results["words"],
+            tokenized_xml=align_results["tokenized"],
+            duration=get_audio_duration(audiofile),
             output_base=output_base,
             output_formats=output_formats,
         )
@@ -889,7 +900,8 @@ def save_readalong(
     # Create webvtt object if outputting to vtt or srt
     if "srt" in output_formats or "vtt" in output_formats:
         save_subtitles(
-            align_results=align_results,
+            words=align_results["words"],
+            tokenized_xml=align_results["tokenized"],
             output_base=output_base,
             output_formats=output_formats,
         )
@@ -956,54 +968,61 @@ def get_ancestor_sent_el(word_el: etree.ElementTree) -> Union[None, etree.Elemen
     return word_el
 
 
-def get_words_and_sentences(results) -> Tuple[List[dict], List[List[dict]]]:
-    """Parse xml into word and sentence 'tier' data
+def get_textual_words_and_sentences(
+    words: List[dict], tokenized_xml: etree.ElementTree
+) -> Tuple[List[dict], List[List[dict]]]:
+    """Parse xml into word and sentence 'tier' data with full textual words
 
     Args:
-        results([TODO type]): the results object returned by align_audio
+        words: list of words with "id", "start" and "end"
+        tokenized_xml: tokenized or g2p'd parsed XML object
 
     Returns:
-        list of words, list of sentences
+        list of words, list of sentences (as a list of lists of words)
+        The returned words are dicts containing:
+           "text": the actual textual word from the XML (not the ID)
+           "start": start time
+           "end": end time
     """
-    all_els = results["words"]
-    xml = results["tokenized"]
     sentences = []
-    words: List[dict] = []
+    sent_words: List[dict] = []
     all_words = []
     prev_sent_el = None
-    for el in all_els:
+    for word in words:
         # The sentence is considered the set of words under the same <s> element.
         # A word that's not under any <s> element is bad input, but we consider
         # it a sentence by itself for software robustness.
-        word_el = get_word_element(xml, el["id"])
+        word_el = get_word_element(tokenized_xml, word["id"])
         sent_el = get_ancestor_sent_el(word_el)
         if prev_sent_el is None or sent_el is not prev_sent_el:
-            if words:
-                sentences.append(words)
-            words = []
+            if sent_words:
+                sentences.append(sent_words)
+            sent_words = []
             prev_sent_el = sent_el
-        word = {
+        textual_word = {
             "text": get_word_text(word_el),
-            "start": el["start"],
-            "end": el["end"],
+            "start": word["start"],
+            "end": word["end"],
         }
-        words.append(word)
-        all_words.append(word)
-    if words:
-        sentences.append(words)
+        sent_words.append(textual_word)
+        all_words.append(textual_word)
+    if sent_words:
+        sentences.append(sent_words)
     return all_words, sentences
 
 
-def write_to_text_grid(words: List[dict], sentences: List[List[dict]], duration: float):
-    """Write results to Praat TextGrid. Because we are using pympi, we can also export to Elan EAF.
+def create_text_grid(
+    words: List[dict], sentences: List[List[dict]], duration: float
+) -> TextGrid:
+    """Create Praat TextGrid from results. Because we are using pympi, we can also export to Elan EAF.
 
     Args:
-        words (List[dict]): List of word times containing start, end, and value keys
-        sentences (List[dict]): List of sentence times containing start, end, and value keys
+        words (List[dict]): List of words containing "text", "start", "end"
+        sentences (List[dict]): List of sentences (as a list of lists of word dicts)
         duration (float): duration of entire audio
 
     Returns:
-        TextGrid: Praat TextGrid with word and sentence alignments
+        TextGrid: Praat TextGrid object with word and sentence alignments
     """
     text_grid = TextGrid(xmax=duration)
     sentence_tier = text_grid.add_tier(name="Sentence")

--- a/readalongs/text/make_smil.py
+++ b/readalongs/text/make_smil.py
@@ -1,14 +1,16 @@
-###################################################################
-#
-# make_smil.py
-#
-#   Turns alignment into formatted SMIL for ReadAlongs WebComponent
-####################################################################
+"""
+make_smil.py
 
+Turns alignment into formatted SMIL for ReadAlongs WebComponent
+"""
+
+from typing import List
 
 import chevron
+from lxml import etree
 
-SMIL_TEMPLATE = """<smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+SMIL_TEMPLATE = """\
+<smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
     <body>
         {{#words}}
         <par id="par-{{id}}">
@@ -28,17 +30,72 @@ WORD_SUBIDX = 2
 END_SUBIDX = 3
 
 
-def make_smil(text_path: str, audio_path: str, results: dict) -> str:
+def make_smil(text_path: str, audio_path: str, words: List[dict]) -> str:
     """Actually render the SMIL
 
+    words is a list of dicts with these elements:
+    {
+        'id': word id (str),
+        'start': word start time in seconds (float),
+        'end': word_end_time_in_seconds (float),
+    }
+
     Args:
-        text_path(str): path to text
-        audio_path(str): path to audio
-        results(dict): all alignements
+        text_path (str): path to text
+        audio_path (str): path to audio
+        words (List[dict]): all alignements
 
     Returns:
         str: formatted SMIL
     """
-    results["text_path"] = text_path
-    results["audio_path"] = audio_path
-    return chevron.render(SMIL_TEMPLATE, results)
+    return chevron.render(
+        SMIL_TEMPLATE,
+        {"text_path": text_path, "audio_path": audio_path, "words": words},
+    )
+
+
+def parse_smil(formatted_smil: str) -> List[dict]:
+    """Extract the list of words and their alignment from a SMIL file content.
+
+    Args:
+        formatted_smil (str): the raw, unparsed XML content of the .smil file
+
+    Returns:
+        List[dict]: a list of dicts with these elements:
+            {
+                'id': word id (str),
+                'start': word start time in seconds (float),
+                'end': word_end_time_in_seconds (float),
+            }
+    Raises:
+        ValueError if there is a problem parsing formatted_smil as valid SMIL
+    """
+
+    please_msg = "Please make sure your SMIL file is valid."
+
+    try:
+        xml = etree.fromstring(formatted_smil)
+    except etree.ParseError as e:
+        raise ValueError(f"Invalid SMIL file: {e}. {please_msg}")
+    ns = {"smil": "http://www.w3.org/ns/SMIL"}
+
+    words = []
+    for par_el in xml.xpath(".//smil:par", namespaces=ns):
+        text_src = par_el.find("smil:text", namespaces=ns).attrib["src"]
+        _, _, text_id = text_src.partition("#")
+        if not text_id:
+            raise ValueError(f"Missing word id. {please_msg}")
+        audio_el = par_el.find("smil:audio", namespaces=ns)
+        try:
+            clip_begin = float(audio_el.attrib["clipBegin"])
+            clip_end = float(audio_el.attrib["clipEnd"])
+        except KeyError as e:
+            raise ValueError(f"Missing 'clipBegin' or 'clipEnd'. {please_msg}") from e
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid 'clipBegin' or 'clipEnd': {e}. {please_msg}."
+            ) from e
+
+        words.append({"id": text_id, "start": clip_begin, "end": clip_end})
+
+    return words

--- a/readalongs/text/make_smil.py
+++ b/readalongs/text/make_smil.py
@@ -35,9 +35,9 @@ def make_smil(text_path: str, audio_path: str, words: List[dict]) -> str:
 
     words is a list of dicts with these elements:
     {
-        'id': word id (str),
-        'start': word start time in seconds (float),
-        'end': word_end_time_in_seconds (float),
+        "id": word id (str),
+        "start": word start time in seconds (float),
+        "end": word_end_time_in_seconds (float),
     }
 
     Args:
@@ -63,9 +63,9 @@ def parse_smil(formatted_smil: str) -> List[dict]:
     Returns:
         List[dict]: a list of dicts with these elements:
             {
-                'id': word id (str),
-                'start': word start time in seconds (float),
-                'end': word_end_time_in_seconds (float),
+                "id": word id (str),
+                "start": word start time in seconds (float),
+                "end": word_end_time_in_seconds (float),
             }
     Raises:
         ValueError if there is a problem parsing formatted_smil as valid SMIL

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -26,7 +26,7 @@ from typing import Dict, List, Optional, Union
 from fastapi import Body, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from lxml import etree
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from readalongs.align import create_tei_from_text
 from readalongs.text.add_ids_to_xml import add_ids
@@ -101,11 +101,23 @@ def process_xml(func):
     return wrapper
 
 
-@v1.get("/langs", response_model=Dict[str, str])
-async def langs() -> Dict[str, str]:
+class LangsResponse(BaseModel):
+    """List of languages supported by Studio, a dictionary of the form {land_id: lang_name}"""
+
+    langs: Dict[str, str] = Field(
+        example={
+            "lc1": "Language Name 1",
+            "lc2": "Language Name 2",
+            "lc3": "Language Name 3",
+        }
+    )
+
+
+@v1.get("/langs", response_model=LangsResponse)
+async def langs() -> LangsResponse:
     """Return the list of supported languages and their names as a dict."""
 
-    return LANGS[1]
+    return LangsResponse(langs=LANGS[1])
 
 
 @v1.post("/assemble", response_model=AssembleResponse)

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -187,7 +187,7 @@ async def assemble(
     g2ped, valid = convert_xml(ids_added)
     if not valid:
         raise HTTPException(
-            status_code=400, detail="g2p could not be performed"
+            status_code=422, detail="g2p could not be performed"
         )  # TODO: do we want to return a 400 here? better error message
     # create grammar
     dict_data, jsgf, text_input = create_grammar(g2ped)

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -21,6 +21,8 @@ http://localhost:8000/api/v1/docs
 
 import io
 import os
+from tempfile import TemporaryDirectory
+from textwrap import dedent
 from typing import Dict, List, Optional, Union
 
 from fastapi import Body, FastAPI, HTTPException
@@ -28,11 +30,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from lxml import etree
 from pydantic import BaseModel, Field
 
-from readalongs.align import create_tei_from_text
+from readalongs.align import create_tei_from_text, save_label_files
 from readalongs.text.add_ids_to_xml import add_ids
 from readalongs.text.convert_xml import convert_xml
 from readalongs.text.make_dict import make_dict_object
 from readalongs.text.make_fsg import make_jsgf
+from readalongs.text.make_smil import parse_smil
 from readalongs.text.tokenize_xml import tokenize_xml
 from readalongs.util import get_langs
 
@@ -213,6 +216,141 @@ def create_grammar(xml):
     fsg_data = make_jsgf(word_elements, filename="test")
     text_data = " ".join(xml.xpath("//w/@id"))
     return dict_data, fsg_data, text_data
+
+
+class ConvertRequest(BaseModel):
+    """Convert Request contains the RAS-processed XML and SMIL alignments"""
+
+    audio_length: float = Field(
+        example=2.01,
+        gt=0.0,
+        title="The length of the audio used to create the alignment, in seconds.",
+    )
+
+    encoding: str = "utf-8"
+
+    xml: str = Field(
+        title="The processed_xml returned by /assemble.",
+        example=dedent(
+            """\
+            <?xml version='1.0' encoding='utf-8'?>
+            <TEI>
+                <text xml:lang="dan" fallback-langs="und" id="t0">
+                    <body id="t0b0">
+                        <div type="page" id="t0b0d0">
+                            <p id="t0b0d0p0">
+                                <s id="t0b0d0p0s0"><w id="t0b0d0p0s0w0" ARPABET="HH EH Y">hej</w> <w id="t0b0d0p0s0w1" ARPABET="V Y D EH N">verden</w></s>
+                            </p>
+                        </div>
+                    </body>
+                </text>
+            </TEI>"""
+        ),
+    )
+
+    smil: str = Field(
+        title="The result of aligning xml to the audio with SoundSwallower(.js)",
+        example=dedent(
+            """\
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+                <body>
+                    <par id="par-t0b0d0p0s0w0">
+                        <text src="hej-verden.xml#t0b0d0p0s0w0"/>
+                        <audio src="hej-verden.mp3" clipBegin="0.14" clipEnd="0.78"/>
+                    </par>
+                    <par id="par-t0b0d0p0s0w1">
+                        <text src="hej-verden.xml#t0b0d0p0s0w1"/>
+                        <audio src="hej-verden.mp3" clipBegin="0.78" clipEnd="1.89"/>
+                    </par>
+                </body>
+            </smil>"""
+        ),
+    )
+
+
+class TextGridResponse(BaseModel):
+    """Convert response has TextGrid file format for the same alignments"""
+
+    textgrid: str = Field(
+        example=dedent(
+            """\
+            File type = "ooTextFile"
+            Object class = "TextGrid"
+
+            xmin = 0.000000
+            xmax = 2.01
+            tiers? <exists>
+            size = 2
+            item []:
+                item [1]:
+                    class = "IntervalTier"
+                    name = "Sentence"
+                    xmin = 0.000000
+                    xmax = 2.01
+                    intervals: size = 3
+                    intervals [1]:
+                        xmin = 0.000000
+                        xmax = 0.140000
+                        text = ""
+                    intervals [2]:
+                        xmin = 0.140000
+                        xmax = 1.890000
+                        text = "hej verden"
+                    intervals [3]:
+                        xmin = 1.890000
+                        xmax = 2.010000
+                        text = ""
+                item [2]:
+                    class = "IntervalTier"
+                    name = "Word"
+                    xmin = 0.000000
+                    xmax = 2.01
+                    intervals: size = 4
+                    intervals [1]:
+                        xmin = 0.000000
+                        xmax = 0.140000
+                        text = ""
+                    intervals [2]:
+                        xmin = 0.140000
+                        xmax = 0.780000
+                        text = "hej"
+                    intervals [3]:
+                        xmin = 0.780000
+                        xmax = 1.890000
+                        text = "verden"
+                    intervals [4]:
+                        xmin = 1.890000
+                        xmax = 2.010000
+                        text = ""
+            """
+        )
+    )
+
+
+@v1.post("/convert_to_TextGrid", response_model=TextGridResponse)
+async def convert_to_TextGrid(input: ConvertRequest) -> TextGridResponse:
+    try:
+        parsed_xml = etree.fromstring(bytes(input.xml, encoding=input.encoding))
+    except etree.XMLSyntaxError as e:
+        raise HTTPException(status_code=422, detail="XML provided is not valid") from e
+
+    if input.encoding not in ["utf-8", "utf8", "UTF-8", "UTF8"]:
+        raise HTTPException(
+            status_code=422, detail="The only encoding actually tested is utf-8..."
+        )
+
+    try:
+        words = parse_smil(input.smil)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail="SMIL provided is not valid") from e
+
+    with TemporaryDirectory() as temp_dir_name:
+        prefix = os.path.join(temp_dir_name, "f")
+        save_label_files(words, parsed_xml, input.audio_length, prefix, "textgrid")
+        with open(prefix + ".TextGrid", mode="r", encoding="utf-8") as f:
+            textgrid_text = f.read()
+
+    return TextGridResponse(textgrid=textgrid_text)
 
 
 # Mount the v1 version of the API to the root of the app

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -227,7 +227,16 @@ class ConvertRequest(BaseModel):
         title="The length of the audio used to create the alignment, in seconds.",
     )
 
-    encoding: str = "utf-8"
+    encoding: str = Field(
+        example="utf-8",
+        title="Only utf-8 is supported now, but contact us if you might need support for a different enciding.",
+    )
+
+    output_format: str = Field(
+        example="TextGrid",
+        regex="^(?i)(eaf|TextGrid)$",
+        title="Format to convert to, one of TextGrid (Praat), eaf (ELAN).",
+    )
 
     xml: str = Field(
         title="The processed_xml returned by /assemble.",
@@ -268,75 +277,41 @@ class ConvertRequest(BaseModel):
     )
 
 
-class TextGridResponse(BaseModel):
-    """Convert response has TextGrid file format for the same alignments"""
+class ConvertResponse(BaseModel):
+    """Convert response has the requesed converted file's contents"""
 
-    textgrid: str = Field(
-        example=dedent(
-            """\
-            File type = "ooTextFile"
-            Object class = "TextGrid"
-
-            xmin = 0.000000
-            xmax = 2.01
-            tiers? <exists>
-            size = 2
-            item []:
-                item [1]:
-                    class = "IntervalTier"
-                    name = "Sentence"
-                    xmin = 0.000000
-                    xmax = 2.01
-                    intervals: size = 3
-                    intervals [1]:
-                        xmin = 0.000000
-                        xmax = 0.140000
-                        text = ""
-                    intervals [2]:
-                        xmin = 0.140000
-                        xmax = 1.890000
-                        text = "hej verden"
-                    intervals [3]:
-                        xmin = 1.890000
-                        xmax = 2.010000
-                        text = ""
-                item [2]:
-                    class = "IntervalTier"
-                    name = "Word"
-                    xmin = 0.000000
-                    xmax = 2.01
-                    intervals: size = 4
-                    intervals [1]:
-                        xmin = 0.000000
-                        xmax = 0.140000
-                        text = ""
-                    intervals [2]:
-                        xmin = 0.140000
-                        xmax = 0.780000
-                        text = "hej"
-                    intervals [3]:
-                        xmin = 0.780000
-                        xmax = 1.890000
-                        text = "verden"
-                    intervals [4]:
-                        xmin = 1.890000
-                        xmax = 2.010000
-                        text = ""
-            """
-        )
+    file_contents: str = Field(
+        title="Full contents of the converted file in the format requested."
     )
 
 
-@v1.post("/convert_to_TextGrid", response_model=TextGridResponse)
-async def convert_to_TextGrid(input: ConvertRequest) -> TextGridResponse:
+@v1.post("/convert_alignment", response_model=ConvertResponse)
+async def convert_alignment(input: ConvertRequest) -> ConvertResponse:
+    """Convert an alignment to a different format.
+
+    Args (as dict items in the request body):
+     - audio_length: duration in seconds of the audio file used to create the alignment
+     - encoding: use utf-8, other encodings are not supported (yet)
+     - output_format: one of TextGrid (Praat), eaf (ELAN), ...
+     - xml: the XML file produced by /assemble
+     - smil: the SMIL file produced by SoundSwallower(.js)
+
+    Data privacy consideration: due to limitations of the libraries used to perform
+    some of these conversions, the output file may be temporarily stored on disk,
+    but it gets deleted immediately, before it is even returned by this endpoint.
+
+    Returns:
+     - file_contents: the contents of the file converted in the requested format
+    """
     try:
         parsed_xml = etree.fromstring(bytes(input.xml, encoding=input.encoding))
     except etree.XMLSyntaxError as e:
         raise HTTPException(status_code=422, detail="XML provided is not valid") from e
 
-    if input.encoding not in ["utf-8", "utf8", "UTF-8", "UTF8"]:
+    if input.encoding not in ["utf-8", "utf8", "UTF-8", "UTF8", ""]:
         raise HTTPException(
-            status_code=422, detail="The only encoding actually tested is utf-8..."
+            status_code=422,
+            detail="Please use utf-8 as your encoding, or contact us with a description of how and why you would like to use a different encoding",
         )
 
     try:
@@ -344,13 +319,30 @@ async def convert_to_TextGrid(input: ConvertRequest) -> TextGridResponse:
     except ValueError as e:
         raise HTTPException(status_code=422, detail="SMIL provided is not valid") from e
 
-    with TemporaryDirectory() as temp_dir_name:
-        prefix = os.path.join(temp_dir_name, "f")
-        save_label_files(words, parsed_xml, input.audio_length, prefix, "textgrid")
-        with open(prefix + ".TextGrid", mode="r", encoding="utf-8") as f:
-            textgrid_text = f.read()
+    output_format = input.output_format.lower()
+    if output_format == "textgrid":
+        with TemporaryDirectory() as temp_dir_name:
+            prefix = os.path.join(temp_dir_name, "f")
+            save_label_files(words, parsed_xml, input.audio_length, prefix, "textgrid")
+            with open(prefix + ".TextGrid", mode="r", encoding="utf-8") as f:
+                textgrid_text = f.read()
 
-    return TextGridResponse(textgrid=textgrid_text)
+        return ConvertResponse(file_contents=textgrid_text)
+
+    elif output_format == "eaf":
+        with TemporaryDirectory() as temp_dir_name:
+            prefix = os.path.join(temp_dir_name, "f")
+            save_label_files(words, parsed_xml, input.audio_length, prefix, "eaf")
+            with open(prefix + ".eaf", mode="r", encoding="utf-8") as f:
+                eaf_text = f.read()
+
+        return ConvertResponse(file_contents=eaf_text)
+
+    else:
+        raise HTTPException(
+            status_code=500,
+            detail="Invalid output_format should have been caught by fastAPI already...",
+        )
 
 
 # Mount the v1 version of the API to the root of the app

--- a/test/run.py
+++ b/test/run.py
@@ -35,6 +35,7 @@ from test_temp_file import TestTempFile
 from test_tokenize_cli import TestTokenizeCli
 from test_tokenize_xml import TestTokenizer
 from test_web_api import TestWebApi
+from test_smil import TestSmilUtilities
 
 from readalongs.log import LOGGER
 
@@ -67,6 +68,7 @@ other_tests = [
         TestG2pCli,
         TestMisc,
         TestSilence,
+        TestSmilUtilities,
         TestPackageURLs,
         TestWebApi,
     ]

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -18,7 +18,7 @@ from readalongs.align import (
     align_audio,
     convert_to_xhtml,
     create_input_tei,
-    get_words_and_sentences,
+    get_textual_words_and_sentences,
 )
 from readalongs.log import LOGGER
 from readalongs.portable_tempfile import PortableNamedTemporaryFile
@@ -63,7 +63,9 @@ class TestForceAlignment(BasicTestCase):
 
         # White-box testing to make sure srt, TextGrid and vtt output will have the
         # sentences collected correctly.
-        words, sentences = get_words_and_sentences(results)
+        words, sentences = get_textual_words_and_sentences(
+            results["words"], results["tokenized"]
+        )
         self.assertEqual(len(sentences), 7)
         self.assertEqual(len(words), 99)
 
@@ -103,7 +105,9 @@ class TestForceAlignment(BasicTestCase):
                 word_el[0].append(make_element("subsyl", "sub;"))
                 word_el.append(make_element("syl", "another syl;"))
                 break
-        _, sentences = get_words_and_sentences(results)
+        _, sentences = get_textual_words_and_sentences(
+            results["words"], results["tokenized"]
+        )
         self.assertEqual(
             [w["text"] for w in sentences[1]],
             [

--- a/test/test_smil.py
+++ b/test/test_smil.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+"""
+Unit test suite for the smil writing and parsing utilities
+"""
+
+from textwrap import dedent
+from unittest import main
+
+from basic_test_case import BasicTestCase
+
+from readalongs.text.make_smil import make_smil, parse_smil
+
+
+class TestSmilUtilities(BasicTestCase):
+    """Unit test suite for the smil writing and parsing utilities"""
+
+    def setUp(self):
+        super().setUp()
+        self.words = [
+            {"id": "w1", "start": 0.01, "end": 0.75},
+            {"id": "w2", "start": 0.8, "end": 1.04},
+            # Make one of the ID's a utf-8 character, to test for handling that correctly.
+            {"id": "wé3", "start": 1.2, "end": 1.33},
+        ]
+        self.smil = dedent(
+            """\
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+                <body>
+                    <par id="par-w1">
+                        <text src="my_text_path#w1"/>
+                        <audio src="my_audio_path" clipBegin="0.01" clipEnd="0.75"/>
+                    </par>
+                    <par id="par-w2">
+                        <text src="my_text_path#w2"/>
+                        <audio src="my_audio_path" clipBegin="0.8" clipEnd="1.04"/>
+                    </par>
+                    <par id="par-wé3">
+                        <text src="my_text_path#wé3"/>
+                        <audio src="my_audio_path" clipBegin="1.2" clipEnd="1.33"/>
+                    </par>
+                </body>
+            </smil>
+            """
+        )
+
+    def test_make_smil(self):
+        text_path = "my_text_path"
+        audio_path = "my_audio_path"
+        smil = make_smil(text_path, audio_path, self.words)
+        self.assertEqual(smil, self.smil)
+
+    def test_parse_smil(self):
+        words = parse_smil(self.smil)
+        self.assertEqual(words, self.words)
+
+    def test_parse_bad_smil(self):
+        with self.assertRaises(ValueError):
+            _ = parse_smil("this is not XML")
+
+        missing_id = dedent(
+            """\
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+                <body>
+                    <par id="par-w1">
+                        <text src="my_text_path"/>
+                        <audio src="my_audio_path" clipBegin="0.01" clipEnd="0.75"/>
+                    </par>
+                </body>
+            </smil>
+            """
+        )
+        with self.assertRaises(ValueError):
+            _ = parse_smil(missing_id)
+
+        missing_clip_end = dedent(
+            """\
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+                <body>
+                    <par id="par-w1">
+                        <text src="my_text_path#w1"/>
+                        <audio src="my_audio_path" clipBegin="0.01"/>
+                    </par>
+                </body>
+            </smil>
+            """
+        )
+        with self.assertRaises(ValueError):
+            _ = parse_smil(missing_clip_end)
+
+        bad_float = dedent(
+            """\
+            <smil xmlns="http://www.w3.org/ns/SMIL" version="3.0">
+                <body>
+                    <par id="par-w1">
+                        <text src="my_text_path#w1"/>
+                        <audio src="my_audio_path" clipBegin="a.bc" clipEnd="2.34"/>
+                    </par>
+                </body>
+            </smil>
+            """
+        )
+        with self.assertRaises(ValueError):
+            _ = parse_smil(bad_float)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -92,7 +92,7 @@ class TestWebApi(BasicTestCase):
         request["text"] = data
         request["text_languages"] = ["test"]
         response = API_CLIENT.post("/api/v1/assemble", json=request)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 422)
 
     def test_langs(self):
         # Test the langs endpoint

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -150,72 +150,6 @@ class TestWebApi(BasicTestCase):
         """
     )
 
-    hej_verden_textgrid = dedent(
-        """\
-        File type = "ooTextFile"
-        Object class = "TextGrid"
-
-        xmin = 0.000000
-        xmax = 83.100000
-        tiers? <exists>
-        size = 2
-        item []:
-            item [1]:
-                class = "IntervalTier"
-                name = "Sentence"
-                xmin = 0.000000
-                xmax = 83.100000
-                intervals: size = 3
-                intervals [1]:
-                    xmin = 0.000000
-                    xmax = 17.745000
-                    text = ""
-                intervals [2]:
-                    xmin = 17.745000
-                    xmax = 82.190000
-                    text = "hej é verden à"
-                intervals [3]:
-                    xmin = 82.190000
-                    xmax = 83.100000
-                    text = ""
-            item [2]:
-                class = "IntervalTier"
-                name = "Word"
-                xmin = 0.000000
-                xmax = 83.100000
-                intervals: size = 4
-                intervals [1]:
-                    xmin = 0.000000
-                    xmax = 17.745000
-                    text = ""
-                intervals [2]:
-                    xmin = 17.745000
-                    xmax = 58.600000
-                    text = "hej é"
-                intervals [3]:
-                    xmin = 58.600000
-                    xmax = 82.190000
-                    text = "verden à"
-                intervals [4]:
-                    xmin = 82.190000
-                    xmax = 83.100000
-                    text = ""
-        """
-    )
-
-    def test_convert_to_TextGrid(self):
-        request = {
-            "encoding": "utf-8",
-            "audio_length": 83.1,
-            "output_format": "TextGrid",
-            "xml": self.hej_verden_xml,
-            "smil": self.hej_verden_smil,
-        }
-        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["file_contents"], self.hej_verden_textgrid)
-        self.assertTrue(response.json()["file_name"].endswith(".TextGrid"))
-
     def test_convert_to_TextGrid_errors(self):
         request = {
             "encoding": "utf-8",
@@ -255,13 +189,78 @@ class TestWebApi(BasicTestCase):
             "smil": self.hej_verden_smil,
         }
         response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
-        # Figure out how to exercise this case, but for now latin-1 is not even supported...
-        # print(response.status_code, response.json())
-        self.assertEqual(
-            response.status_code, 422, "only utf-8 is allowed at the moment."
-        )
+        # Figure out how to exercise this case, but for now only utf-8 is supported...
+        # print("latin-1", response.status_code, response.json())
+        self.assertEqual(response.status_code, 422, "only utf-8 is supported for now")
         # Or, once we do support latin-1:
         # self.assertEqual(response.status_code, 400)
+
+    def test_convert_to_TextGrid(self):
+        request = {
+            "encoding": "utf-8",
+            "audio_length": 83.1,
+            "output_format": "TextGrid",
+            "xml": self.hej_verden_xml,
+            "smil": self.hej_verden_smil,
+        }
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["file_name"].endswith(".TextGrid"))
+        self.assertEqual(
+            response.json()["file_contents"],
+            dedent(
+                """\
+                File type = "ooTextFile"
+                Object class = "TextGrid"
+
+                xmin = 0.000000
+                xmax = 83.100000
+                tiers? <exists>
+                size = 2
+                item []:
+                    item [1]:
+                        class = "IntervalTier"
+                        name = "Sentence"
+                        xmin = 0.000000
+                        xmax = 83.100000
+                        intervals: size = 3
+                        intervals [1]:
+                            xmin = 0.000000
+                            xmax = 17.745000
+                            text = ""
+                        intervals [2]:
+                            xmin = 17.745000
+                            xmax = 82.190000
+                            text = "hej é verden à"
+                        intervals [3]:
+                            xmin = 82.190000
+                            xmax = 83.100000
+                            text = ""
+                    item [2]:
+                        class = "IntervalTier"
+                        name = "Word"
+                        xmin = 0.000000
+                        xmax = 83.100000
+                        intervals: size = 4
+                        intervals [1]:
+                            xmin = 0.000000
+                            xmax = 17.745000
+                            text = ""
+                        intervals [2]:
+                            xmin = 17.745000
+                            xmax = 58.600000
+                            text = "hej é"
+                        intervals [3]:
+                            xmin = 58.600000
+                            xmax = 82.190000
+                            text = "verden à"
+                        intervals [4]:
+                            xmin = 82.190000
+                            xmax = 83.100000
+                            text = ""
+                """
+            ),
+        )
 
     def test_convert_to_eaf(self):
         request = {

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -97,8 +97,8 @@ class TestWebApi(BasicTestCase):
     def test_langs(self):
         # Test the langs endpoint
         response = API_CLIENT.get("/api/v1/langs")
-        self.assertEqual(response.json(), get_langs()[1])
-        self.assertEqual(set(response.json().keys()), set(get_langs()[0]))
+        self.assertEqual(response.json()["langs"], get_langs()[1])
+        self.assertEqual(set(response.json()["langs"].keys()), set(get_langs()[0]))
 
     def test_debug(self):
         # Test the assemble endpoint with debug mode on

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -214,6 +214,7 @@ class TestWebApi(BasicTestCase):
         response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["file_contents"], self.hej_verden_textgrid)
+        self.assertTrue(response.json()["file_name"].endswith(".TextGrid"))
 
     def test_convert_to_TextGrid_errors(self):
         request = {
@@ -273,6 +274,84 @@ class TestWebApi(BasicTestCase):
         response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 200)
         self.assertIn("<ANNOTATION_DOCUMENT", response.json()["file_contents"])
+        self.assertTrue(response.json()["file_name"].endswith(".eaf"))
+
+    def test_convert_to_srt(self):
+        request = {
+            "encoding": "utf-8",
+            "audio_length": 83.1,
+            "output_format": "srt",
+            "xml": self.hej_verden_xml,
+            "smil": self.hej_verden_smil,
+        }
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["file_name"].endswith("_sentences.srt"))
+        self.assertTrue(response.json()["other_file_name"].endswith("_words.srt"))
+        self.assertEqual(
+            response.json()["file_contents"],
+            dedent(
+                """\
+                1
+                00:00:17,745 --> 00:01:22,190
+                hej é verden à
+
+                """
+            ),
+        )
+        self.assertEqual(
+            response.json()["other_file_contents"],
+            dedent(
+                """\
+                1
+                00:00:17,745 --> 00:00:58,600
+                hej é
+
+                2
+                00:00:58,600 --> 00:01:22,190
+                verden à
+
+                """
+            ),
+        )
+
+    def test_convert_to_vtt(self):
+        request = {
+            "encoding": "utf-8",
+            "audio_length": 83.1,
+            "output_format": "vtt",
+            "xml": self.hej_verden_xml,
+            "smil": self.hej_verden_smil,
+        }
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["file_name"].endswith("_sentences.vtt"))
+        self.assertTrue(response.json()["other_file_name"].endswith("_words.vtt"))
+        self.assertEqual(
+            response.json()["file_contents"],
+            dedent(
+                """\
+                WEBVTT
+
+                00:00:17.745 --> 00:01:22.190
+                hej é verden à
+                """
+            ),
+        )
+        self.assertEqual(
+            response.json()["other_file_contents"],
+            dedent(
+                """\
+                WEBVTT
+
+                00:00:17.745 --> 00:00:58.600
+                hej é
+
+                00:00:58.600 --> 00:01:22.190
+                verden à
+                """
+            ),
+        )
 
     def test_convert_to_bad_format(self):
         request = {

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -207,48 +207,53 @@ class TestWebApi(BasicTestCase):
         request = {
             "encoding": "utf-8",
             "audio_length": 83.1,
+            "output_format": "TextGrid",
             "xml": self.hej_verden_xml,
             "smil": self.hej_verden_smil,
         }
-        response = API_CLIENT.post("/api/v1/convert_to_TextGrid", json=request)
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["textgrid"], self.hej_verden_textgrid)
+        self.assertEqual(response.json()["file_contents"], self.hej_verden_textgrid)
 
     def test_convert_to_TextGrid_errors(self):
         request = {
             "encoding": "utf-8",
             "audio_length": 83.1,
+            "output_format": "TextGrid",
             "xml": "this is not XML",
             "smil": self.hej_verden_smil,
         }
-        response = API_CLIENT.post("/api/v1/convert_to_TextGrid", json=request)
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 422, "Invalid XML should fail.")
 
         request = {
             "encoding": "utf-8",
             "audio_length": 83.1,
+            "output_format": "TextGrid",
             "xml": self.hej_verden_xml,
             "smil": "This is not SMIL",
         }
-        response = API_CLIENT.post("/api/v1/convert_to_TextGrid", json=request)
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 422, "Invalid SMIL should fail.")
 
         request = {
             "encoding": "utf-8",
             "audio_length": -10.0,
+            "output_format": "TextGrid",
             "xml": self.hej_verden_xml,
             "smil": self.hej_verden_smil,
         }
-        response = API_CLIENT.post("/api/v1/convert_to_TextGrid", json=request)
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 422, "Negative duration should fail.")
 
         request = {
             "encoding": "latin-1",
             "audio_length": 83.1,
+            "output_format": "TextGrid",
             "xml": self.hej_verden_xml,
             "smil": self.hej_verden_smil,
         }
-        response = API_CLIENT.post("/api/v1/convert_to_TextGrid", json=request)
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
         # Figure out how to exercise this case, but for now latin-1 is not even supported...
         # print(response.status_code, response.json())
         self.assertEqual(
@@ -256,6 +261,39 @@ class TestWebApi(BasicTestCase):
         )
         # Or, once we do support latin-1:
         # self.assertEqual(response.status_code, 400)
+
+    def test_convert_to_eaf(self):
+        request = {
+            "encoding": "utf-8",
+            "audio_length": 83.1,
+            "output_format": "eaf",
+            "xml": self.hej_verden_xml,
+            "smil": self.hej_verden_smil,
+        }
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("<ANNOTATION_DOCUMENT", response.json()["file_contents"])
+
+    def test_convert_to_bad_format(self):
+        request = {
+            "encoding": "utf-8",
+            "audio_length": 83.1,
+            "output_format": "not_a_known_format",
+            "xml": self.hej_verden_xml,
+            "smil": self.hej_verden_smil,
+        }
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        self.assertEqual(response.status_code, 422)
+
+        request = {
+            "encoding": "utf-8",
+            "audio_length": 83.1,
+            # "output_format" just missing
+            "xml": self.hej_verden_xml,
+            "smil": self.hej_verden_smil,
+        }
+        response = API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        self.assertEqual(response.status_code, 422)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Feature implementation: the /convert_alignment endpoint support converting alignments to TextGrid, eaf, srt, vtt.

Breaking change: the /langs endpoint's return value has changed in order to be better documented