### PR TITLE
ci: fix deprecation warnings for actions/create-release and set-output

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -28,20 +28,18 @@ jobs:
       - name: Determine tag
         id: determine_tag
         run: |
-          echo "::set-output name=TAG_VERSION::$(ls dist/readalongs-*.tar.gz | sed -e 's/.*readalongs-//' -e 's/.tar.gz.*//')"
+          echo "TAG_VERSION=$(ls dist/readalongs-*.tar.gz | sed -e 's/.*readalongs-//' -e 's/.tar.gz.*//')" >> $GITHUB_OUTPUT
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.5
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ steps.determine_tag.outputs.TAG_VERSION }}
       - name: Create a GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
       - name: Submit a PR for the bumped version
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
1) Replace deprecated actions/create-release by ncipollo/release-action

   https://github.com/actions/create-release is deprecated so we should
   stop using it. ncipollo/release-action is one of its maintained
   replacements, and the one our mathieudutour/github-tag-action actions
   uses in their documentation.

   Linted with https://rhysd.github.io/actionlint/ but we can't really test
   this without creating a new release, so we'll have to test it when it's
   time to create the next release.

2) ci: replace deprecated set-output and bump github-tag-action

   Refs for set-output:
    - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
    - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
   
   For mathieudutour/github-tag-action, we were using v5.5 which used set-output and Node.js 12, both deprecated. @v6.1 fixes both.