### PR TITLE
Make the "readalong" format with its own DTD

### DIFF
--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -176,7 +176,7 @@ def parse_and_make_xml(
     """Parse XML input and run tokenization and G2P.
 
     Args:
-        xml_path (str): Path to XML input file in TEI-like format
+        xml_path (str): Path to XML input file in RAS format
         config (dict): Optional; ReadAlong-Studio configuration to use
         save_temps (str): Optional; Save temporary files, by default None
         verbose_g2p_warnings (boolean): Optional; display all g2p errors and warnings
@@ -541,7 +541,7 @@ def align_audio(
     """Align an XML input file to an audio file.
 
     Args:
-        xml_path (str): Path to XML input file in TEI-like format
+        xml_path (str): Path to XML input file in RAS format
         audio_path (str): Path to audio input. Must be in a format supported by ffmpeg
         unit (str): Optional; Element to create alignments for, by default 'w'
         bare (boolean): Optional;
@@ -1120,8 +1120,8 @@ def convert_to_xhtml(tokenized_xml, title="Book"):
     head.append(link_element)
 
 
-TEI_TEMPLATE = """<?xml version='1.0' encoding='utf-8'?>
-<TEI>
+RAS_TEMPLATE = """<?xml version='1.0' encoding='utf-8'?>
+<readalong>
     <text xml:lang="{{main_lang}}" fallback-langs="{{fallback_langs}}">
         <body>
         {{#pages}}
@@ -1137,12 +1137,12 @@ TEI_TEMPLATE = """<?xml version='1.0' encoding='utf-8'?>
         {{/pages}}
         </body>
     </text>
-</TEI>
+</readalong>
 """
 
 
-def create_tei_from_text(lines: Iterable[str], text_languages=Sequence[str]) -> str:
-    """Create input xml in TEI standard.
+def create_ras_from_text(lines: Iterable[str], text_languages=Sequence[str]) -> str:
+    """Create input xml in RAS format.
         Uses the line sequence to infer paragraph and sentence structure from plain text:
         Assumes a double blank line marks a page break, and a single blank line
         marks a paragraph break.
@@ -1184,11 +1184,11 @@ def create_tei_from_text(lines: Iterable[str], text_languages=Sequence[str]) -> 
         paragraphs.append({"sentences": sentences})
     if paragraphs:
         pages.append({"paragraphs": paragraphs})
-    return chevron.render(TEI_TEMPLATE, {**kwargs, **{"pages": pages}})
+    return chevron.render(RAS_TEMPLATE, {**kwargs, **{"pages": pages}})
 
 
-def create_input_tei(**kwargs):
-    """Create input xml in TEI standard.
+def create_input_ras(**kwargs):
+    """Create input xml in RAS format.
         Uses readlines to infer paragraph and sentence structure from plain text.
         Assumes a double blank line marks a page break, and a single blank line
         marks a paragraph break.
@@ -1241,7 +1241,7 @@ def create_input_tei(**kwargs):
             prefix="readalongs_xml_", suffix=".xml", delete=True
         )
         filename = outfile.name
-    xml = create_tei_from_text(text, text_langs)
+    xml = create_ras_from_text(text, text_langs)
     outfile.write(xml.encode("utf-8"))
     outfile.flush()
     outfile.close()

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -20,7 +20,7 @@ import click
 from lxml import etree
 
 from readalongs._version import __version__
-from readalongs.align import align_audio, create_input_tei, save_readalong
+from readalongs.align import align_audio, create_input_ras, save_readalong
 from readalongs.log import LOGGER
 from readalongs.text.add_ids_to_xml import add_ids
 from readalongs.text.convert_xml import convert_xml
@@ -369,7 +369,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
             languages.append("und")
         plain_textfile = kwargs["textfile"]
         try:
-            _, xml_textfile = create_input_tei(
+            _, xml_textfile = create_input_ras(
                 input_file_name=plain_textfile,
                 text_languages=languages,
                 save_temps=temp_base,
@@ -532,7 +532,7 @@ def make_xml(**kwargs):
 
     try:
         if out_file == "-":
-            _, filename = create_input_tei(
+            _, filename = create_input_ras(
                 input_file_handle=input_file, text_languages=languages
             )
             with io.open(filename, encoding="utf-8-sig") as f:
@@ -545,7 +545,7 @@ def make_xml(**kwargs):
                     "Output file %s exists already, use -f to overwrite." % out_file
                 )
 
-            _, filename = create_input_tei(
+            _, filename = create_input_ras(
                 input_file_handle=input_file,
                 text_languages=languages,
                 output_file=out_file,

--- a/readalongs/static/readalong.dtd
+++ b/readalongs/static/readalong.dtd
@@ -1,11 +1,14 @@
 <!ELEMENT readalong (text)>
-<!ELEMENT text (body)>
+<!ELEMENT text (body|anchor)*>
 <!ATTLIST text
  fallback-langs CDATA #IMPLIED
+ xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED>
 
 <!ELEMENT body (div|anchor|graphic|p|s|w)*>
-<!ATTLIST body id CDATA #IMPLIED>
+<!ATTLIST body
+ xml:lang CDATA #IMPLIED
+ id CDATA #IMPLIED>
 
 <!ELEMENT anchor EMPTY>
 <!ATTLIST anchor time CDATA #REQUIRED>
@@ -17,21 +20,24 @@
 
 <!ELEMENT div (#PCDATA|anchor|graphic|p|s|w)*>
 <!ATTLIST div
+ xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  type CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
  duration CDATA #IMPLIED>
 
-<!ELEMENT p (#PCDATA|s|w)*>
+<!ELEMENT p (#PCDATA|anchor|s|w)*>
 <!ATTLIST p
+ xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
  duration CDATA #IMPLIED>
 
-<!ELEMENT s (#PCDATA|w)*>
+<!ELEMENT s (#PCDATA|anchor|w)*>
 <!ATTLIST s
+ xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  class CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
@@ -40,6 +46,7 @@
 
 <!ELEMENT w (#PCDATA)>
 <!ATTLIST w
+ xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  ARPABET CDATA #IMPLIED

--- a/readalongs/static/readalong.dtd
+++ b/readalongs/static/readalong.dtd
@@ -1,0 +1,42 @@
+<!ELEMENT readalong (text)>
+<!ELEMENT text (body)>
+<!ATTLIST text xml:lang CDATA "und"
+ fallback-langs CDATA #IMPLIED
+ id CDATA #IMPLIED>
+
+<!ELEMENT body (div|anchor|graphic|p|s|w)*>
+<!ATTLIST body id CDATA #IMPLIED>
+
+<!ELEMENT anchor EMPTY>
+<!ATTLIST anchor time CDATA #REQUIRED>
+
+<!ELEMENT graphic EMPTY>
+<!ATTLIST graphic url CDATA #REQUIRED
+                  id CDATA #IMPLIED>
+
+<!ELEMENT div (#PCDATA|anchor|graphic|p|s|w)*>
+<!ATTLIST div id CDATA #IMPLIED
+          type CDATA #IMPLIED
+          do-not-align CDATA #IMPLIED
+          time CDATA #IMPLIED
+          duration CDATA #IMPLIED>
+
+<!ELEMENT p (#PCDATA|s|w)*>
+<!ATTLIST p id CDATA #IMPLIED
+ do-not-align CDATA #IMPLIED
+ time CDATA #IMPLIED
+ duration CDATA #IMPLIED>
+
+<!ELEMENT s (#PCDATA|w)*>
+<!ATTLIST s id CDATA #IMPLIED
+ class CDATA #IMPLIED
+ do-not-align CDATA #IMPLIED
+ time CDATA #IMPLIED
+ duration CDATA #IMPLIED>
+
+<!ELEMENT w (#PCDATA)>
+<!ATTLIST w id CDATA #IMPLIED
+ do-not-align CDATA #IMPLIED
+ ARPABET CDATA #IMPLIED
+ time CDATA #IMPLIED
+ duration CDATA #IMPLIED>

--- a/readalongs/static/readalong.dtd
+++ b/readalongs/static/readalong.dtd
@@ -1,11 +1,12 @@
 <!ELEMENT readalong (text)>
 <!ELEMENT text (body|anchor)*>
 <!ATTLIST text
- fallback-langs CDATA #IMPLIED
  xml:lang CDATA #IMPLIED
+ lang CDATA #IMPLIED
+ fallback-langs CDATA #IMPLIED
  id CDATA #IMPLIED>
 
-<!ELEMENT body (div|anchor|graphic|p|s|w)*>
+<!ELEMENT body (div|anchor|silence|graphic|p|s|w)*>
 <!ATTLIST body
  xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED>
@@ -13,42 +14,54 @@
 <!ELEMENT anchor EMPTY>
 <!ATTLIST anchor time CDATA #REQUIRED>
 
+<!ELEMENT silence EMPTY>
+<!ATTLIST silence dur CDATA #REQUIRED>
+
 <!ELEMENT graphic EMPTY>
 <!ATTLIST graphic
  url CDATA #REQUIRED
  id CDATA #IMPLIED>
 
-<!ELEMENT div (#PCDATA|anchor|graphic|p|s|w)*>
+<!ELEMENT div (#PCDATA|anchor|silence|graphic|p|s|w)*>
 <!ATTLIST div
  xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  type CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
- duration CDATA #IMPLIED>
+ dur CDATA #IMPLIED>
 
-<!ELEMENT p (#PCDATA|anchor|s|w)*>
+<!ELEMENT p (#PCDATA|anchor|silence|s|w)*>
 <!ATTLIST p
  xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
- duration CDATA #IMPLIED>
+ dur CDATA #IMPLIED>
 
-<!ELEMENT s (#PCDATA|anchor|w)*>
+<!ELEMENT s (#PCDATA|anchor|silence|w)*>
 <!ATTLIST s
  xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  class CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
- duration CDATA #IMPLIED>
+ dur CDATA #IMPLIED>
 
-<!ELEMENT w (#PCDATA)>
+<!ELEMENT w (#PCDATA|syl)*>
 <!ATTLIST w
  xml:lang CDATA #IMPLIED
  id CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  ARPABET CDATA #IMPLIED
  time CDATA #IMPLIED
- duration CDATA #IMPLIED>
+ dur CDATA #IMPLIED>
+
+<!ELEMENT syl (#PCDATA)>
+<!ATTLIST syl
+ xml:lang CDATA #IMPLIED
+ id CDATA #IMPLIED
+ do-not-align CDATA #IMPLIED
+ ARPABET CDATA #IMPLIED
+ time CDATA #IMPLIED
+ dur CDATA #IMPLIED>

--- a/readalongs/static/readalong.dtd
+++ b/readalongs/static/readalong.dtd
@@ -1,6 +1,6 @@
 <!ELEMENT readalong (text)>
 <!ELEMENT text (body)>
-<!ATTLIST text xml:lang CDATA "und"
+<!ATTLIST text
  fallback-langs CDATA #IMPLIED
  id CDATA #IMPLIED>
 
@@ -11,31 +11,36 @@
 <!ATTLIST anchor time CDATA #REQUIRED>
 
 <!ELEMENT graphic EMPTY>
-<!ATTLIST graphic url CDATA #REQUIRED
-                  id CDATA #IMPLIED>
+<!ATTLIST graphic
+ url CDATA #REQUIRED
+ id CDATA #IMPLIED>
 
 <!ELEMENT div (#PCDATA|anchor|graphic|p|s|w)*>
-<!ATTLIST div id CDATA #IMPLIED
-          type CDATA #IMPLIED
-          do-not-align CDATA #IMPLIED
-          time CDATA #IMPLIED
-          duration CDATA #IMPLIED>
+<!ATTLIST div
+ id CDATA #IMPLIED
+ type CDATA #IMPLIED
+ do-not-align CDATA #IMPLIED
+ time CDATA #IMPLIED
+ duration CDATA #IMPLIED>
 
 <!ELEMENT p (#PCDATA|s|w)*>
-<!ATTLIST p id CDATA #IMPLIED
+<!ATTLIST p
+ id CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
  duration CDATA #IMPLIED>
 
 <!ELEMENT s (#PCDATA|w)*>
-<!ATTLIST s id CDATA #IMPLIED
+<!ATTLIST s
+ id CDATA #IMPLIED
  class CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  time CDATA #IMPLIED
  duration CDATA #IMPLIED>
 
 <!ELEMENT w (#PCDATA)>
-<!ATTLIST w id CDATA #IMPLIED
+<!ATTLIST w
+ id CDATA #IMPLIED
  do-not-align CDATA #IMPLIED
  ARPABET CDATA #IMPLIED
  time CDATA #IMPLIED

--- a/readalongs/text/add_ids_to_xml.py
+++ b/readalongs/text/add_ids_to_xml.py
@@ -9,7 +9,7 @@
 #
 # The auto-generated IDs have formats like "s0w2m1" meaning
 # "sentence 0, word 2, morpheme 1".  But it's flexible if some elements
-# already have ids, or if the markup uses different tags than a TEI document.
+# already have ids, or if the markup uses different tags than a RAS document.
 #
 ###################################################
 

--- a/readalongs/text/convert_xml.py
+++ b/readalongs/text/convert_xml.py
@@ -21,7 +21,7 @@
 # second part to the Kwak'wala pipeline.
 #
 # The only assumption made by this module about the structure of the XML
-# is that it has word tags (using <w>, the convention used by TEI formats.)
+# is that it has word tags (using <w>, the convention used by RAS and TEI formats.)
 # The reason for this is that the word is the domain over which phonological
 # rules apply, and we particularly need to know it to be able to perform
 # phonological rules at word boundaries.  We also only convert text that

--- a/readalongs/text/end_to_end.py
+++ b/readalongs/text/end_to_end.py
@@ -5,7 +5,7 @@
 #
 # end_to_end.py
 #
-# Takes an XML file (preferrably using TEI conventions) and
+# Takes an XML file (preferrably using TEI conventions or RAS format) and
 # makes:
 #
 # 1. An XML file with added IDs for elements (if the elements didn't

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -240,7 +240,6 @@ class ConvertRequest(BaseModel):
         example=dedent(
             """\
             <?xml version='1.0' encoding='utf-8'?>
-            <!DOCDTYPE readalong SYSTEM "readalong.dtd">
             <readalong>
                 <text xml:lang="dan" fallback-langs="und" id="t0">
                     <body id="t0b0">

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -35,7 +35,7 @@ from lxml import etree
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTask
 
-from readalongs.align import create_tei_from_text, save_label_files, save_subtitles
+from readalongs.align import create_ras_from_text, save_label_files, save_subtitles
 from readalongs.log import LOGGER
 from readalongs.text.add_ids_to_xml import add_ids
 from readalongs.text.convert_xml import convert_xml
@@ -132,7 +132,7 @@ async def assemble(
             "xml": {
                 "summary": "A basic example with xml input",
                 "value": {
-                    "xml": "<?xml version='1.0' encoding='utf-8'?><TEI><text><p><s>hej verden</s></p></text></TEI>",
+                    "xml": "<?xml version='1.0' encoding='utf-8'?><readalong><text><p><s>hej verden</s></p></text></readalong>",
                     "text_languages": ["dan", "und"],
                     "debug": False,
                 },
@@ -140,7 +140,7 @@ async def assemble(
         }
     )
 ):
-    """Create an input TEI from the given text (as plain text or XML).
+    """Create an input RAS from the given text (as plain text or XML).
     Also creates the required grammar, pronunciation dictionary,
     and text needed by the decoder.
 
@@ -174,7 +174,7 @@ async def assemble(
         parsed = io.StringIO(request.text).readlines()
         parsed = etree.fromstring(
             bytes(
-                create_tei_from_text(parsed, text_languages=request.text_languages),
+                create_ras_from_text(parsed, text_languages=request.text_languages),
                 encoding="utf-8",
             ),
             parser=etree.XMLParser(resolve_entities=False),
@@ -240,7 +240,8 @@ class ConvertRequest(BaseModel):
         example=dedent(
             """\
             <?xml version='1.0' encoding='utf-8'?>
-            <TEI>
+            <!DOCDTYPE readalong SYSTEM "readalong.dtd">
+            <readalong>
                 <text xml:lang="dan" fallback-langs="und" id="t0">
                     <body id="t0b0">
                         <div type="page" id="t0b0d0">
@@ -250,7 +251,7 @@ class ConvertRequest(BaseModel):
                         </div>
                     </body>
                 </text>
-            </TEI>"""
+            </readalong>"""
         ),
     )
 

--- a/test/basic_test_case.py
+++ b/test/basic_test_case.py
@@ -28,7 +28,7 @@ class BasicTestCase(TestCase):
     # To keep temp dirs for just one subclass, add this line to its setUp() function:
     # function before the call to super().setUp():
     #     self.keep_temp_dir_after_running = True
-    keep_temp_dir_after_running = False
+    keep_temp_dir_after_running = True
 
     def setUp(self):
         """Create a temporary directory, self.tempdir, and a test runner, self.runner

--- a/test/basic_test_case.py
+++ b/test/basic_test_case.py
@@ -28,7 +28,7 @@ class BasicTestCase(TestCase):
     # To keep temp dirs for just one subclass, add this line to its setUp() function:
     # function before the call to super().setUp():
     #     self.keep_temp_dir_after_running = True
-    keep_temp_dir_after_running = True
+    keep_temp_dir_after_running = False
 
     def setUp(self):
         """Create a temporary directory, self.tempdir, and a test runner, self.runner

--- a/test/data/ej-fra-anchors.xml
+++ b/test/data/ej-fra-anchors.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -23,4 +23,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra-anchors2.xml
+++ b/test/data/ej-fra-anchors2.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <anchor time=".5s"/>
         <body>
@@ -25,4 +25,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra-converted.xml
+++ b/test/data/ej-fra-converted.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra" id="t0">
         <body id="t0b0">
             <div type="page" id="t0b0d0">
@@ -21,4 +21,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra-dna.xml
+++ b/test/data/ej-fra-dna.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -28,4 +28,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra-package.xml
+++ b/test/data/ej-fra-package.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -23,4 +23,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra-silence-bad.xml
+++ b/test/data/ej-fra-silence-bad.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -21,4 +21,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra-silence.xml
+++ b/test/data/ej-fra-silence.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -21,4 +21,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/ej-fra.xml
+++ b/test/data/ej-fra.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -21,4 +21,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/fra-prepared.xml
+++ b/test/data/fra-prepared.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra" fallback-langs="und">
         <body>
             <div type="page">
@@ -21,4 +21,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/fra-tokenized.xml
+++ b/test/data/fra-tokenized.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text xml:lang="fra">
         <body>
             <div type="page">
@@ -21,4 +21,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/mixed-langs.g2p.xml
+++ b/test/data/mixed-langs.g2p.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text id="t0">
         <body id="t0b0">
             <div type="page" id="t0b0d0">
@@ -12,4 +12,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/mixed-langs.tokenized.xml
+++ b/test/data/mixed-langs.tokenized.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text>
         <body>
             <div type="page">
@@ -12,4 +12,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/mixed-langs.xml
+++ b/test/data/mixed-langs.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <text>
         <body>
             <div type="page">
@@ -12,4 +12,4 @@
             </div>
         </body>
     </text>
-</TEI>
+</readalong>

--- a/test/data/patrickxtlan.xml
+++ b/test/data/patrickxtlan.xml
@@ -1,8 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <readalong>
+  <text>
+    <body>
     <p>
         <s><w xml:lang="eng">Patrick</w><w xml:lang="kwk-umista">xtła̱n</w></s>
         <s><w xml:lang="und">Patrickxtła̱n</w></s>
 	<s><w>foo<syl xml:lang="eng">Patrick</syl>bar<syl xml:lang="kwk-umista">xtła̱n</syl>baz</w></s>
     </p>
+    </body>
+  </text>
 </readalong>

--- a/test/data/patrickxtlan.xml
+++ b/test/data/patrickxtlan.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<TEI>
+<readalong>
     <p>
         <s><w xml:lang="eng">Patrick</w><w xml:lang="kwk-umista">xtła̱n</w></s>
         <s><w xml:lang="und">Patrickxtła̱n</w></s>
 	<s><w>foo<syl xml:lang="eng">Patrick</syl>bar<syl xml:lang="kwk-umista">xtła̱n</syl>baz</w></s>
     </p>
-</TEI>
+</readalong>

--- a/test/test_align_cli.py
+++ b/test/test_align_cli.py
@@ -316,9 +316,9 @@ class TestAlignCli(BasicTestCase):
         """Make sure invalid anchors yield appropriate errors"""
 
         xml_text = """<?xml version='1.0' encoding='utf-8'?>
-            <TEI><text xml:lang="fra"><body><p>
+            <readalong><text xml:lang="fra"><body><p>
             <anchor /><s>Bonjour.</s><anchor time="invalid"/>
-            </p></body></text></TEI>
+            </p></body></text></readalong>
         """
         xml_file = join(self.tempdir, "bad-anchor.xml")
         with open(xml_file, "w", encoding="utf8") as f:

--- a/test/test_force_align.py
+++ b/test/test_force_align.py
@@ -17,7 +17,7 @@ from soundswallower import get_model_path
 from readalongs.align import (
     align_audio,
     convert_to_xhtml,
-    create_input_tei,
+    create_input_ras,
     get_word_texts_and_sentences,
 )
 from readalongs.log import LOGGER
@@ -47,7 +47,7 @@ class TestForceAlignment(BasicTestCase):
         """Basic alignment test case with plain text input"""
         txt_path = os.path.join(self.data_dir, "ej-fra.txt")
         wav_path = os.path.join(self.data_dir, "ej-fra.m4a")
-        _, temp_fn = create_input_tei(
+        _, temp_fn = create_input_ras(
             input_file_name=txt_path, text_languages=("fra",), save_temps=None
         )
         results = align_audio(temp_fn, wav_path, unit="w", save_temps=None)

--- a/test/test_make_xml_cli.py
+++ b/test/test_make_xml_cli.py
@@ -10,7 +10,7 @@ from unittest import main
 
 from basic_test_case import BasicTestCase
 
-from readalongs.align import create_input_tei, create_tei_from_text
+from readalongs.align import create_input_ras, create_ras_from_text
 from readalongs.cli import align, make_xml
 
 # from readalongs.log import LOGGER
@@ -170,18 +170,18 @@ class TestMakeXMLCli(BasicTestCase):
             "Using old Mac-style newlines should not affect make-xml",
         )
 
-    def test_create_input_tei_errors(self):
-        """create_input_tei should raise a AssertionError when parameters are missing."""
+    def test_create_input_ras_errors(self):
+        """create_input_ras should raise a AssertionError when parameters are missing."""
         # These used to be RuntimeError, but that was not right: *programmer*
         # errors can and should dump stack traces, unlike *user* errors, which
         # warrant nice friendly messages.
         with self.assertRaises(AssertionError):
             # missing input_file_name or input_file_handle
-            _, _ = create_input_tei()
+            _, _ = create_input_ras()
 
         with self.assertRaises(AssertionError):
             # missing text_languages
-            _, _ = create_input_tei(
+            _, _ = create_input_ras(
                 input_file_name=os.path.join(self.data_dir, "fra.txt")
             )
 
@@ -213,19 +213,19 @@ class TestMakeXMLCli(BasicTestCase):
     def test_make_xml_invalid_utf8_input(self):
         noise_file = os.path.join(self.data_dir, "noise.mp3")
 
-        # Read noise.mp3 as if it was utf8 text, via create_input_tei(input_file_handle)
+        # Read noise.mp3 as if it was utf8 text, via create_input_ras(input_file_handle)
         results = self.runner.invoke(make_xml, ["-l", "fra", noise_file, "-"])
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("provide a correctly encoded utf-8", results.output)
 
-        # Read noise.mp3 as if it was utf8 text, via create_input_tei(input_file_name)
+        # Read noise.mp3 as if it was utf8 text, via create_input_ras(input_file_name)
         results = self.runner.invoke(
             make_xml, ["-l", "fra", noise_file, os.path.join(self.tempdir, "noise.xml")]
         )
         self.assertNotEqual(results.exit_code, 0)
         self.assertIn("provide a correctly encoded utf-8", results.output)
 
-        # align also calls create_input_tei(input_file_name)
+        # align also calls create_input_ras(input_file_name)
         results = self.runner.invoke(
             align,
             [
@@ -245,8 +245,8 @@ class TestMakeXMLCli(BasicTestCase):
         input_text_stripped = "Ceci est un test\n\nParagraphe\n\n\nPage\n"
 
         self.assertEqual(
-            create_tei_from_text(text2lines(input_text_with_spaces), ["fra"]),
-            create_tei_from_text(text2lines(input_text_stripped), ["fra"]),
+            create_ras_from_text(text2lines(input_text_with_spaces), ["fra"]),
+            create_ras_from_text(text2lines(input_text_stripped), ["fra"]),
         )
 
     def test_ignore_superfluous_blank_lines(self):
@@ -258,24 +258,24 @@ class TestMakeXMLCli(BasicTestCase):
 
         self.maxDiff = None
         self.assertEqual(
-            create_tei_from_text(text2lines(input_text_with_extra_nls), ["eng"]),
-            create_tei_from_text(text2lines(input_text_stripped), ["eng"]),
+            create_ras_from_text(text2lines(input_text_with_extra_nls), ["eng"]),
+            create_ras_from_text(text2lines(input_text_stripped), ["eng"]),
         )
 
         for n in range(3, 10):
             self.assertEqual(
-                create_tei_from_text(text2lines("Page1" + "\n" * n + "Page2"), ["eng"]),
-                create_tei_from_text(text2lines("Page1" + "\n" * 3 + "Page2"), ["eng"]),
+                create_ras_from_text(text2lines("Page1" + "\n" * n + "Page2"), ["eng"]),
+                create_ras_from_text(text2lines("Page1" + "\n" * 3 + "Page2"), ["eng"]),
             )
 
     def test_split_vs_readlines(self):
-        """Calling create_tei_from_text should work any way we split the lines"""
+        """Calling create_ras_from_text should work any way we split the lines"""
         # string.split("\n") strips newlines and might not be identical to readlines(),
         # but that should make no difference to create_tei_from_text
         text = "Blah\nBlah\n\nFoo \n\n \nBar"
         self.assertEqual(
-            create_tei_from_text(text.split("\n"), ["eng"]),
-            create_tei_from_text(text2lines(text), ["eng"]),
+            create_ras_from_text(text.split("\n"), ["eng"]),
+            create_ras_from_text(text2lines(text), ["eng"]),
         )
 
 

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -86,8 +86,8 @@ class TestMisc(BasicTestCase):
         self.assertEqual(words, ref)
 
     def test_get_attrib_recursive(self):
-        raw_xml = """<TEI>
-            <text lang="text">
+        raw_xml = """<readalong>
+            <text xml:lang="text">
             <p lang="p1"><s>stuff</s><s lang="p1s2">nonsense</s></p>
             <p><s lang="p2s1">stuff</s><s>nonsense</s></p>
             </text>
@@ -97,7 +97,7 @@ class TestMisc(BasicTestCase):
             <text>
             <p><s xml:lang="p4s1" lang="not:xml:lang">stuff</s><s>nonsense<s xml:lang="p4p2c">!</s></s></p>
             </text>
-            </TEI>
+            </readalong>
         """
         xml = etree.fromstring(raw_xml)
         for i, s, lang in zip(

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -87,7 +87,7 @@ class TestMisc(BasicTestCase):
 
     def test_get_attrib_recursive(self):
         raw_xml = """<readalong>
-            <text xml:lang="text">
+            <text lang="text">
             <p lang="p1"><s>stuff</s><s lang="p1s2">nonsense</s></p>
             <p><s lang="p2s1">stuff</s><s>nonsense</s></p>
             </text>

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -122,7 +122,7 @@ class TestWebApi(BasicTestCase):
     hej_verden_xml = dedent(
         """\
         <?xml version='1.0' encoding='utf-8'?>
-        <TEI>
+        <readalong>
             <text xml:lang="dan" fallback-langs="und" id="t0">
                 <body id="t0b0">
                     <div type="page" id="t0b0d0">
@@ -132,7 +132,7 @@ class TestWebApi(BasicTestCase):
                     </div>
                 </body>
             </text>
-        </TEI>
+        </readalong>
         """
     )
 
@@ -368,7 +368,7 @@ class TestWebApi(BasicTestCase):
         mismatch_xml = dedent(
             """\
             <?xml version='1.0' encoding='utf-8'?>
-            <TEI>
+            <readalong>
                 <text xml:lang="dan" fallback-langs="und" id="t0">
                     <body id="t0b0">
                         <div type="page" id="t0b0d0">
@@ -378,7 +378,7 @@ class TestWebApi(BasicTestCase):
                         </div>
                     </body>
                 </text>
-            </TEI>
+            </readalong>
             """
         )
         request = {


### PR DESCRIPTION
Since we are modifying TEI in a sort of ad-hoc manner it is preferable to call it something other than TEI.  This additionally will allow us to have a single standalone file with both text and alignments rather than a separate SMIL file (which we can still generate for the case where it is necesary, e.g. EPUB)

TODO:
- validate sample and test files against the DTD in unit tests (lxml can do this)
- put time/duration in the RAS file