### PR TITLE
Introduce better CORS environment variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests
         run: |
           gunicorn readalongs.app:app --bind 0.0.0.0:5000 --daemon
-          cd test && coverage run run.py prod && coverage xml
+          cd test && coverage run run.py prod && DEVELOPMENT=1 coverage run test_web_api.py && coverage xml
 
       - name: Nitpicking
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,11 @@ jobs:
 
       - name: Run tests
         run: |
-          gunicorn readalongs.app:app --bind 0.0.0.0:5000 --daemon
-          cd test && coverage run run.py prod && DEVELOPMENT=1 coverage run test_web_api.py && coverage xml
+          cd test
+          coverage run --parallel-mode run.py prod
+          DEVELOPMENT=1 coverage run --parallel-mode test_web_api.py
+          coverage combine
+          coverage xml
 
       - name: Nitpicking
         run: |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ This page lists only the most basic commands.
 
 For more information about how the command line interface works consult the interactive [API Documentation](https://readalong-studio.herokuapp.com/api/v1/docs).
 
-For information on spinning up your own dev Web API server locally, have a look at [web\_api.py](readalongs/web_api.py).
+For information on spinning up your own dev Web API server locally, have a look at [web\_api.py](readalongs/web_api.py), but briefly, if you are running it locally for development, use:
+
+    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload
 
 #### /langs
 

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -56,6 +56,9 @@ from readalongs.util import get_langs
 web_api_app = FastAPI()
 middleware_args: Dict[str, Union[str, List[str]]]
 if os.getenv("DEVELOPMENT", False):
+    LOGGER.info(
+        "Running in development mode, will allow requests from http://localhost:*"
+    )
     # Allow requests from localhost dev servers
     middleware_args = dict(
         allow_origin_regex="http://localhost(:.*)?",

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -1,17 +1,23 @@
-"""
-REST-ish Web API for ReadAlongs Studio text manipulation operations using FastAPI.
+"""REST-ish Web API for ReadAlongs Studio text manipulation operations using FastAPI.
 
 See https://readalong-studio.herokuapp.com/api/v1/docs for the documentation.
 
 You can spin up this Web API for development purposes on any platform with:
     pip install uvicorn
     cd readalongs/
-    PRODUCTION= uvicorn readalongs.web_api:web_api_app --reload
+    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload
 - The --reload switch will watch for changes under the directory where it's
   running and reload the code whenever it changes, so it's best run in readalongs/
-- PRODUCTION= tells uvicorn to run in non-production mode, i.e., in debug mode,
-  and automatically add the header "access-control-allow-origin: *" to each
-  response so you won't get CORS errors using this locally with Studio-Web.
+- DEVELOPMENT=1 tells the API to accept cross-origin requests (i.e. by sending the
+  appropriate CORS headers) from development servers running on localhost, e.g.
+  http://localhost:4200
+
+For deployment, you can use the ORIGIN environment variable to set the URL of your
+application in order to make it accept requests from that site.  For instance if
+you deployed an application that uses it (such as Studio-Web) at
+https://my.awesome.site you would set ORIGIN=https://my.awesome.site in your
+environment variables.  This is usually done through an environment variable file
+(or in a dashboard) and will depend on your hosting environment.
 
 You can also spin up the API server grade (on Linux, not Windows) with gunicorn:
     pip install -r requirements.api.txt
@@ -19,6 +25,7 @@ You can also spin up the API server grade (on Linux, not Windows) with gunicorn:
 
 Once spun up, the documentation and API playground will be visible at
 http://localhost:8000/api/v1/docs
+
 """
 
 import io


### PR DESCRIPTION
instead of the confusing PRODUCTION= you now do DEVELOPMENT=1 (or anything else truthy), and you can also explicitly specify the deployed origin URL with ORIGIN if you like for production mode (fixes #146)