### PR TITLE
Web API: Capture assemble logs

### DIFF
--- a/readalongs/log.py
+++ b/readalongs/log.py
@@ -2,7 +2,9 @@
 log.py: Setup a logger that has colours!
 """
 
+import io
 import logging
+from contextlib import contextmanager
 
 import coloredlogs
 
@@ -29,3 +31,25 @@ def setup_logger(name):
 
 
 LOGGER = setup_logger("root")
+
+
+@contextmanager
+def capture_logs():
+    """Context manager to capture the logs in a StringIO within the managed context
+
+    Usage:
+        with capture_logs() as captured_logs:
+            do stuff that logs
+        logging_output = captured_log.getvalue()
+    """
+    log_capture_stream = io.StringIO()
+    stream_handler = logging.StreamHandler(log_capture_stream)
+    stream_handler.setLevel(logging.INFO)
+    LOGGER.addHandler(stream_handler)  # capture logging output
+    LOGGER.propagate = False  # suppresses logging output to console
+
+    try:
+        yield log_capture_stream
+    finally:
+        LOGGER.removeHandler(stream_handler)
+        LOGGER.propagate = True

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -127,13 +127,12 @@ async def langs() -> List[SupportedLanguage]:
         default display name (usually, but not always, in English).
         For example:
 
-        ```[
+        [
             {"code": "alq", names: { "alq": "Anishinaabemowin", "_": "Algonquin" }},
             {"code": "atj", names: { "atj": "Nehiromowin", "_": "Atikamekw" }},
             {"code": "fra", names: { "fra": "Français", "_": "French" }},
             ...
-        }```
-
+        ]
     """
     langs, lang_names = LANGS
     return sorted(

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -235,7 +235,8 @@ async def assemble(
         if not valid:
             raise HTTPException(
                 status_code=422,
-                detail="g2p could not be performed, please check your text or your language code",
+                detail="g2p could not be performed, please check your text or your language code. Logs: "
+                + captured_logs.getvalue(),
             )
         # create grammar
         dict_data, text_input = create_grammar(g2ped)

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -98,6 +98,7 @@ class TestWebApi(BasicTestCase):
         }
         with self.assertLogs(LOGGER, "ERROR"):
             response = API_CLIENT.post("/api/v2/assemble", json=request)
+        # print(response.content)
         self.assertEqual(response.status_code, 422)
 
     def test_langs(self):
@@ -107,6 +108,19 @@ class TestWebApi(BasicTestCase):
         self.assertEqual(
             dict((x["code"], x["names"]["_"]) for x in response.json()), get_langs()[1]
         )
+
+    def test_logs(self):
+        # Test that we see the g2p warnings
+        request = {
+            "input": "Ceci mais pas ña",
+            "type": "text/plain",
+            "debug": True,
+            "text_languages": ["fra", "und"],
+        }
+        response = API_CLIENT.post("/api/v2/assemble", json=request)
+        content = response.json()
+        # print("Content", content)
+        self.assertIn('Could not g2p "ña" as fra', content["log"])
 
     def test_debug(self):
         # Test the assemble endpoint with debug mode on

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -101,6 +101,18 @@ class TestWebApi(BasicTestCase):
         # print(response.content)
         self.assertEqual(response.status_code, 422)
 
+    def test_g2p_faiture(self):
+        # Test the assemble endpoint where g2p actually fails
+        request = {
+            "input": "ceci ña",
+            "type": "text/plain",
+            "text_languages": ["fra"],
+        }
+        response = API_CLIENT.post("/api/v2/assemble", json=request)
+        self.assertEqual(response.status_code, 422)
+        content = response.json()
+        self.assertIn("No valid g2p conversion", content["detail"])
+
     def test_langs(self):
         # Test the langs endpoint
         response = API_CLIENT.get("/api/v2/langs")


### PR DESCRIPTION
Addresses https://github.com/ReadAlongs/Web-Component/issues/92 at least in part, in that g2p logs and everything else `/assemble` logs now goes to a `log` field in the JSON payload.

I did not capture the logs from `/langs` since that received no input and doesn't log anything anyway.

I did not (yet) capture the logs from `/convert_alignment` but I think I should do that one too.