### PR TITLE
fix: where there are no words to align, return 422, not 500

### DIFF
--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -227,6 +227,13 @@ async def assemble(
 
         # tokenize
         tokenized = tokenize_xml(parsed)
+
+        if not tokenized.xpath(".//w"):
+            raise HTTPException(
+                status_code=422,
+                detail="Could not find any words to align in the text.",
+            )
+
         # add ids
         ids_added = add_ids(tokenized)
 

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -112,6 +112,18 @@ class TestWebApi(BasicTestCase):
         content = response.json()
         self.assertIn("No valid g2p conversion", content["detail"])
 
+    def test_no_words(self):
+        # Test the assemble endpoint with no actual words in the text
+        request = {
+            "input": ".!",
+            "type": "text/plain",
+            "text_languages": ["eng"],
+        }
+        response = API_CLIENT.post("/api/v1/assemble", json=request)
+        self.assertEqual(response.status_code, 422)
+        content = response.json()
+        self.assertIn("Could not find any words", content["detail"])
+
     def test_langs(self):
         # Test the langs endpoint
         response = API_CLIENT.get("/api/v1/langs")


### PR DESCRIPTION
500 was internal error, but aligning something like `.` as the whole text should yield a clear message to the user, not an internal error.