### PR TITLE
Make cli.py set its output encoding to utf8, don't rely on g2p

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,3 +78,12 @@ jobs:
 
       - name: Run tests on Windows
         run: cd test && python run.py prod
+
+      - name: Make sure the CLI outputs utf8 on Windows
+        # Note: we're checking something CLI specific, from a prompt, so we don't want to run
+        # in from a testing harness or framework, we want direct CLI.
+        # This test will fail if the output encoding is cp1252
+        # Warning: the diff line below is PowerShell syntax, not bash!
+        run: |
+          echo ćś | readalongs make-xml -l fra - - > cs.readalong
+          if (diff (cat cs.readalong) (cat test/data/cs-ref.readalong)) { throw "Output did not match reference" }

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -47,6 +47,13 @@ SUPPORTED_OUTPUT_FORMATS_DESC = ", ".join(
 )
 
 
+if "pytest" not in sys.modules:
+    if sys.stdout.encoding != "utf8" and hasattr(sys.stdout, "buffer"):
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf8")
+    if sys.stderr.encoding != "utf8" and hasattr(sys.stderr, "buffer"):
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf8")
+
+
 def get_click_file_name(click_file):
     """Wrapper around click_file.name with consistent handling for stdin
 

--- a/test/data/cs-ref.readalong
+++ b/test/data/cs-ref.readalong
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='utf-8'?>
+<read-along version="1.0">
+    <text xml:lang="fra" fallback-langs="und">
+        <body>
+            <div type="page">
+                <p>
+                    <s>ćś</s>
+                </p>
+            </div>
+        </body>
+    </text>
+</read-along>


### PR DESCRIPTION
Until now, we relied on the side effect of `g2p/__init__.py` setting the stdout and stderr encoding to utf8, except that that was incompatible with pytest, and it really is not a good global practice at all. Any program driver that needs to set the output encoding should do it, it should not be a hidden side effect of importing a library.

Fixes https://github.com/roedoejet/g2p/issues/243 on the Studio side of things.