### PR TITLE
build: force the latest g2p@main for heroku

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -3,3 +3,5 @@
 gunicorn
 # uvicorn works on all platforms and is required for both dev and prod deployments
 uvicorn
+# For deployment on Heroku, we want the latest g2p off GitHub
+g2p @ git+https://github.com/roedoejet/g2p.git@main


### PR DESCRIPTION
The idea of this commit is that studio as published on PyPI still depends on a g2p release as declared in `requirements.min.txt`, but the live system on Heroku uses the current main branch from GitHub instead.