### PR TITLE
fix: g2p main is about to be 2.0, but we still want 1.1 on Heroku

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -3,5 +3,3 @@
 gunicorn
 # uvicorn works on all platforms and is required for both dev and prod deployments
 uvicorn
-# For deployment on Heroku, we want the latest g2p off GitHub
-g2p @ git+https://github.com/roedoejet/g2p.git@main

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -3,7 +3,7 @@ chevron==0.14.0
 click>=8.0.4
 coloredlogs==10.0
 fastapi==0.78.0
-g2p>=1.1.20230511, ==1.*
+g2p>=1.1.20230822, ==1.*
 lxml==4.9.1
 networkx>=2.5,<=2.8.4
 numpy>=1.16.4


### PR DESCRIPTION
We had changed things so Heroku builds always took origin/main for g2p, but now that we're working on g2p 2.0 with breaking changes, we have to revert this change and get the latest g2p 1.1.* release instead.

Fixes #186