### PR TITLE
Actually switch to using latest g2p

### DIFF
--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -3,8 +3,7 @@ anyio<4.0.0
 chevron==0.14.0
 click>=8.0.4
 coloredlogs==10.0
-fastapi>=0.78.0
-# Note: when we move g2p to >=2, we will need fastapi>=0.100.0 which requires httpx
+fastapi>=0.100.0
 g2p>=1.1.20230822, <2.1
 httpx>=0.24.1
 lxml==4.9.1


### PR DESCRIPTION
Not sure if there is a good reason we aren't doing this, perhaps I missed it in a comment thread somewhere.

Basically the requirements here, for whatever reason, actually result in uninstalling the latest g2p when you install Studio, which is a problem since we are now fixing things in that version of g2p...