### PR TITLE
lock numpy < 2

### DIFF
--- a/readalongs/log.py
+++ b/readalongs/log.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 
 import coloredlogs
 
-FIELD_STYLES = dict(levelname=dict(color="green", bold=coloredlogs.CAN_USE_BOLD_FONT))
+FIELD_STYLES = dict(levelname=dict(color="green"))
 
 
 def setup_logger(name):

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -2,7 +2,7 @@
 anyio<4.0.0
 chevron==0.14.0
 click>=8.0.4
-coloredlogs==10.0
+coloredlogs>=10.0
 fastapi>=0.78.0
 # Note: when we move g2p to >=2, we will need fastapi>=0.100.0 which requires httpx
 g2p>=1.1.20230822, <2.1

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -9,7 +9,7 @@ g2p>=1.1.20230822, <2.1
 httpx>=0.24.1
 lxml==4.9.1
 networkx>=2.6
-numpy>=1.16.4
+numpy>=1.20.2,<2
 pydub==0.23.1
 pympi-ling>=1.69,<2.0
 python-slugify==5.0.0


### PR DESCRIPTION
See: https://pythonspeed.com/articles/numpy-2

When numpy 2.0.0 is actually out, we'll want to test g2p and our other projects against it before allowing it.

Also fix the bold bug with coloredlogs, long ago fixed in g2p, which prevented us from updating it.