### PR TITLE
Bump lxml to a version compatible with Python 3.11 on Windows

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -11,11 +11,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          # We're not compatible with Python 3.11 on Windows yet.
-          # We get a compilation error about libxml2 when building lxml.
-          - os: windows-latest
-            python-version: "3.11"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -7,7 +7,7 @@ fastapi>=0.78.0
 # Note: when we move g2p to >=2, we will need fastapi>=0.100.0 which requires httpx
 g2p>=1.1.20230822, <2.1
 httpx>=0.24.1
-lxml==4.9.1
+lxml==4.9.4
 networkx>=2.6
 numpy>=1.20.2,<2
 pydub==0.23.1


### PR DESCRIPTION
This makes RAS properly compatible with Python 3.11 everywhere, although installation on Windows will require a compiler until the SoundSwallower wheels are published for 3.11 (see https://github.com/ReadAlongs/SoundSwallower/issues/60)