### PR TITLE
style: bump black to 23

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 # This is a set of development dependencies
-black~=22.0
+black~=23.0
 flake8>=4.0.1
 gitlint-core==0.17.0
 isort>=5.10.1


### PR DESCRIPTION
No code changes to commit, the differences between black 22 and 23 do not currently affect the code base because I committed those changes a while ago.

When we merge this, developers should reinstall black with  `pip install -r requirements.dev.txt` in their Python environments.