### PR TITLE
fix: editdistance can now come from PyPI again for Py 3.12

### DIFF
--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -3,8 +3,6 @@ anyio<4.0.0
 chevron==0.14.0
 click>=8.0.4
 coloredlogs>=10.0
-# Need to install this specifically from git as the sdist is broken
-editdistance @ git+https://github.com/roy-ht/editdistance.git@v0.6.2 ; python_version == '3.12'
 fastapi>=0.100.0
 g2p>=1.1.20230822, <2.1
 httpx>=0.24.1


### PR DESCRIPTION
The authors published 0.8.1 with proper 3.12 packages.

Fixes: #202