### PR TITLE
build(deps)!: drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -1,5 +1,5 @@
 # This matrix testing is for versions not already exercised by tests.yml
-# For regular pushes, we just test the baseline Python version, but when pushing
+# For regular pushes, we just test the minimum Python version, but when pushing
 # to main or release, we want to exercise the full matrix.
 name: Run Matrix Tests
 on:
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
 
       - name: Install Python dependencies
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
 
       - name: Install Python dependencies

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.8"
   jobs:
     post_install:
       - echo "Installing Studio itself in its current state"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Optionally a book can be generated as a standalone HTML page, XHTML, Praat TextG
 
 Before you can install the ReadAlong Studio, you will need to install these dependencies:
 
- - Python, version 3.7 or higher,
+ - Python, version 3.8 or higher,
  - [FFmpeg](https://ffmpeg.org/),
  - a C compiler,
  - Git (optional, needed to get the current development version).

--- a/readalongs/__init__.py
+++ b/readalongs/__init__.py
@@ -12,8 +12,8 @@ import sys
 
 VERSION = "1.0"
 
-if sys.version_info < (3, 7, 0):  # pragma: no cover
+if sys.version_info < (3, 8, 0):  # pragma: no cover
     sys.exit(
-        f"Python 3.7 or more recent is required. You are using {sys.version}. "
+        f"Python 3.8 or more recent is required. You are using {sys.version}. "
         "Please use a newer version of Python."
     )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf8") as f:
 setup(
     name="readalongs",
     license="MIT",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     version=VERSION,
     description="ReadAlong Studio",
     url="https://github.com/ReadAlongs/Studio",


### PR DESCRIPTION
Python 3.7 support ended in July 2023, and package updates will no longer be published for it, so we won't be able to apply all CVE patches if we want to keep supporting Python 3.7.

While there are good reasons to keep supporting Python 3.7 for g2p, there aren't for ReadAlongs/Studio: our CLI users have enough technical background to bump Python if need be, while the Studio-Web meets the requirements of our less technical users.

BREAKING CHANGE: Python 3.7 is no longer supported