### PR TITLE
Fix pydantic issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,6 @@ repos:
         stages: [commit]
 -   repo: https://github.com/pycqa/flake8
     # do flake8 last to avoid duplicate reports
-    rev: 3.8.3
+    rev: 7.0.0
     hooks:
     -   id: flake8

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -316,7 +316,7 @@ class ConvertRequest(BaseModel):
     """Convert Request contains the RAS-processed XML"""
 
     dur: Union[float, None] = Field(
-        example=2.01,
+        examples=[2.01],
         gt=0.0,
         title="The duration of the audio used to create the alignment, in seconds.",
         default=None,
@@ -324,24 +324,26 @@ class ConvertRequest(BaseModel):
 
     ras: str = Field(
         title="The time-aligned XML output produced by `readalongs align`.",
-        example=dedent(
-            """\
-            <?xml version='1.0' encoding='utf-8'?>
-            <read-along version="1.0">
-                <text xml:lang="dan" fallback-langs="und" id="t0">
-                    <body id="t0b0">
-                        <div type="page" id="t0b0d0">
-                            <p id="t0b0d0p0">
-                                <s id="t0b0d0p0s0">
-                                    <w id="t0b0d0p0s0w0" ARPABET="HH EH Y" time="0.14" dur="0.64">hej</w>
-                                    <w id="t0b0d0p0s0w1" ARPABET="V Y D EH N" time="0.78" dur="1.11">verden</w>
-                                </s>
-                            </p>
-                        </div>
-                    </body>
-                </text>
-            </read-along>"""
-        ),
+        examples=[
+            dedent(
+                """\
+                <?xml version='1.0' encoding='utf-8'?>
+                <read-along version="1.0">
+                    <text xml:lang="dan" fallback-langs="und" id="t0">
+                        <body id="t0b0">
+                            <div type="page" id="t0b0d0">
+                                <p id="t0b0d0p0">
+                                    <s id="t0b0d0p0s0">
+                                        <w id="t0b0d0p0s0w0" ARPABET="HH EH Y" time="0.14" dur="0.64">hej</w>
+                                        <w id="t0b0d0p0s0w1" ARPABET="V Y D EH N" time="0.78" dur="1.11">verden</w>
+                                    </s>
+                                </p>
+                            </div>
+                        </body>
+                    </text>
+                </read-along>"""
+            )
+        ],
     )
 
 

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -9,6 +9,7 @@ httpx>=0.24.1
 lxml==4.9.4
 networkx>=2.6
 numpy>=1.20.2,<2
+pydantic>=1.8.2,<3
 pydub==0.23.1
 pympi-ling>=1.69,<2.0
 python-slugify==5.0.0


### PR DESCRIPTION
 - Declare our dependency on Pydantic. We're actually super relaxed: `web_api.py` breaks with Pydantic 1.7, but works fine from 1.8.2 to 2.x, so I made it that broad. I'm going to rely on FastAPI's exclusions to block out "bad" version, I don't feel the need to duplicate that here. E.g., `fastapi==0.110.1` wants `pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4` (!!!)
 - Pydantic 2 does not allow `Field(example="foo")`, only `Field(examples=["foo"])`, while Pydantic 1 is happy with either, so let's only use the latter to suppress the deprecation warning.
 - And the ancient flake8 use used in `.pre-commit-config.yaml` was broken on my machine, so I bumped it to the current version.

Fixes #215