### PR TITLE
fix: more places where the current dtd 1.2 version is needed

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -67,7 +67,7 @@ The format of the generated XML is based on [TEI
 Lite](https://tei-c.org/guidelines/customization/lite/) but is
 considerably simplified.  The DTD (document type definition) can be
 found in the ReadAlong Studio source code under
-`readalongs/static/read-along-1.1.dtd`.
+`readalongs/static/read-along-1.2.dtd`.
 
 (dna)=
 

--- a/readalongs/align.py
+++ b/readalongs/align.py
@@ -181,7 +181,7 @@ def parse_and_make_xml(
     """Parse XML input and run tokenization and G2P.
 
     Args:
-        xml_path (str): Path to input in ReadAlong XML format (see static/read-along-1.1.dtd)
+        xml_path (str): Path to input in ReadAlong XML format (see static/read-along-1.2.dtd)
         config (dict): Optional; ReadAlong-Studio configuration to use
         save_temps (str): Optional; Save temporary files, by default None
         verbose_g2p_warnings (boolean): Optional; display all g2p errors and warnings
@@ -574,7 +574,7 @@ def align_audio(
     """Align an XML input file to an audio file.
 
     Args:
-        xml_path (str): Path to input file in ReadAlong XML format (see static/read-along-1.1.dtd)
+        xml_path (str): Path to input file in ReadAlong XML format (see static/read-along-1.2.dtd)
         audio_path (str): Path to audio input. Must be in a format supported by ffmpeg
         unit (str): Optional; Element to create alignments for, by default 'w'
         bare (boolean): Optional;
@@ -1192,7 +1192,7 @@ RAS_TEMPLATE = """<?xml version='1.0' encoding='utf-8'?>
 
 
 def create_ras_from_text(lines: Iterable[str], text_languages=Sequence[str]) -> str:
-    """Create input xml in ReadAlong XML format (see static/read-along-1.1.dtd)
+    """Create input xml in ReadAlong XML format (see static/read-along-1.2.dtd)
         Uses the line sequence to infer paragraph and sentence structure from plain text:
         Assumes a double blank line marks a page break, and a single blank line
         marks a paragraph break.
@@ -1240,7 +1240,7 @@ def create_ras_from_text(lines: Iterable[str], text_languages=Sequence[str]) -> 
 
 
 def create_input_ras(**kwargs):
-    """Create input xml in ReadAlong XML format (see static/read-along-1.1.dtd)
+    """Create input xml in ReadAlong XML format (see static/read-along-1.2.dtd)
         Uses readlines to infer paragraph and sentence structure from plain text.
         Assumes a double blank line marks a page break, and a single blank line
         marks a paragraph break.

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -78,7 +78,7 @@ v1 = FastAPI()
 # Call get_langs() when the server loads to load the languages into memory
 LANGS = get_langs()
 # Get the DTD
-DTDPATH = os.path.join(os.path.dirname(__file__), "static", "read-along-1.1.dtd")
+DTDPATH = os.path.join(os.path.dirname(__file__), "static", "read-along-1.2.dtd")
 with open(DTDPATH) as dtdfh:
     DTD = etree.DTD(dtdfh)
 


### PR DESCRIPTION
I believe these additional places need the version bumped to match the latest dtd version too, but I'd like confirmation I'm not misinterpreting anything here.