### PR TITLE
fix: fix (or attempt to fix) the pypi publication process

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -41,10 +41,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
 
       - name: Build
         run: python -m build --sdist --wheel
+
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
 
       - name: Update CHANGELOG
         id: changelog
@@ -61,8 +68,35 @@ jobs:
           body: ${{ steps.changelog.outputs.changes }}
           token: ${{ github.token }}
 
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload dist/*
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verbose: true
+
+  deploy-docs:
+    # Create latest docs
+    runs-on: ubuntu-latest
+    needs:
+      - publish
+    permissions:
+      contents: write  # to push to the gh-pages branch
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed to get the gh-pages branch
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.8"
+      - name: Install dependencies and Studio
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+          pip install -r docs/requirements.txt -e .
+      - name: Setup doc deploy
+        run: |
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: Deploy docs with mike 🚀
+        run: |
+          mike deploy --push --update-aliases ${{ github.ref_name }} stable latest


### PR DESCRIPTION
Nothing works today. 🙁
Can't publish studio.
Finding last minutes bugs in studio-web.
Bleh.

Here, I'm guessing the way we published to pypi is no longer supported. See #240.

This code is mimicked from g2p, but not tested. Please review carefully.

Before this can work, we'll need to add the PYPI_API_TOKEN to this repo's secrets, and we can probably remove the obsolete PyPI username and password secrets since they don't work anymore anyway.