### PR TITLE
fix: repair how multiple examples are declared in web_api

### DIFF
--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -145,28 +145,26 @@ async def langs() -> List[SupportedLanguage]:
 @v1.post("/assemble", response_model=AssembleResponse)
 async def assemble(
     request: AssembleRequest = Body(
-        examples=[
-            {
-                "text": {
-                    "summary": "A basic example with plain text input",
-                    "value": {
-                        "input": "hej verden",
-                        "type": "text/plain",
-                        "text_languages": ["dan", "und"],
-                        "debug": False,
-                    },
+        openapi_examples={
+            "text": {
+                "summary": "A basic example with plain text input",
+                "value": {
+                    "input": "hej verden",
+                    "type": "text/plain",
+                    "text_languages": ["dan", "und"],
+                    "debug": False,
                 },
-                "xml": {
-                    "summary": "A basic example with xml input",
-                    "value": {
-                        "input": "<?xml version='1.0' encoding='utf-8'?><read-along version=\"1.0\"><text><p><s>hej verden</s></p></text></read-along>",
-                        "type": "application/readalong+xml",
-                        "text_languages": ["dan", "und"],
-                        "debug": False,
-                    },
+            },
+            "xml": {
+                "summary": "A basic example with xml input",
+                "value": {
+                    "input": "<?xml version='1.0' encoding='utf-8'?><read-along version=\"1.0\"><text><p><s>hej verden</s></p></text></read-along>",
+                    "type": "application/readalong+xml",
+                    "text_languages": ["dan", "und"],
+                    "debug": False,
                 },
-            }
-        ]
+            },
+        }
     ),
 ):
     """Create an input RAS from the given text (as plain text or XML).
@@ -331,7 +329,7 @@ class ConvertRequest(BaseModel):
                 """\
                 <?xml version='1.0' encoding='utf-8'?>
                 <read-along version="%s">
-    <meta name="generator" content="@readalongs/studio (cli) %s"/>
+                    <meta name="generator" content="@readalongs/studio (cli) %s"/>
                     <text xml:lang="dan" fallback-langs="und" id="t0">
                         <body id="t0b0">
                             <div type="page" id="t0b0d0">

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -2,7 +2,7 @@
 chevron==0.14.0
 click>=8.0.4
 coloredlogs>=10.0
-fastapi>=0.100.0
+fastapi>=0.103.0
 g2p>=1.1.20230822, <3
 lxml==4.9.4
 numpy>=1.20.2


### PR DESCRIPTION
Before fastapi 0.99, we could declare multiple examples with

    examples=[{"key1": ..., "key2": ...}]

Now, examples no longer accept keys or metadata, just a list of plain examples.

Since fastapi 0.103, using openapi_examples instead restores the old key and metadata functionality.

See https://fastapi.tiangolo.com/tutorial/schema-extra-example/#using-the-openapi_examples-parameter for details.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Make the examples for `/assemble` work again on https://readalong-studio.herokuapp.com/api/v1/docs#/default/assemble_assemble_post

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Currently, the proposed example is invalid:

![image](https://github.com/user-attachments/assets/ece40d8a-cd5f-402a-b41b-e895a9126d2a)

This PR brings it back to what we used to have:

![image](https://github.com/user-attachments/assets/01e2f03a-1ebc-4d96-b435-b77b71d41f63)

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

```
    pip install uvicorn
    cd readalongs/
    DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload
```
then navigate to 
http://localhost:8000/api/v1/docs#/default/assemble_assemble_post
and see the two examples being proposed instead of the big invalid block.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
