### PR TITLE
feat: add run-web-api.sh to easy launch dev mode API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ For information on spinning up your own dev Web API server locally, have a look 
 
     DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload
 
+or
+
+    ./run-web-api.sh
+
+Note that the production command line for the Web API is defined in [Procfile](Procfile) and documented in [web\_api.py](readalongs/web_api.py).
+
 #### /langs
 
 To query a list of available languages in the ReadAlong Studio API, send a GET request to https://readalongs-studio.herokuapp.com/api/v1/langs

--- a/run-web-api.sh
+++ b/run-web-api.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Convenience script to launch the Web API in development mode.
+# Do not use in production!  (See ../Procfile for the prod launch command.)
+#
+# Usage:
+#    pip install uvicorn
+#    /path/to/run-web-api.sh
+#
+# Further documentation is in readalongs/web_api.py
+
+# Move to the code root directory, so that --reload works correctly.
+CODE_ROOT_PATH=$(dirname $(realpath $0))/readalongs
+cd $CODE_ROOT_PATH
+
+# Launch the Web API with the --reload option, which will automatically reload
+# the server whenver the code changes.
+DEVELOPMENT=1 uvicorn readalongs.web_api:web_api_app --reload


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Stop repeating myself when I want to run the web api, but scripting this command I always have to look up and cut-and-paste!

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Simplifies launching the Web API in dev mode.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

n/a

### How to test? <!-- Explain how reviewers should test this PR. -->

Run `./run-web-api.sh`, or `/path/to/sandboxes/Studio/run-web-api.sh` from anywhere, and see the dev web API launched at http://127.0.0.1:8000/api/v1/docs 

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
