### PR TITLE
Silence all test suites

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,19 +17,19 @@ repos:
         entry: isort
         language: system
         types: [python]
-        stages: [commit]
+        stages: [pre-commit]
     -   id: black
         name: black
         entry: black
         language: system
         types: [python]
-        stages: [commit]
+        stages: [pre-commit]
     -   id: mypy
         name: mypy
         entry: mypy
         language: system
         types: [python]
-        stages: [commit]
+        stages: [pre-commit]
 -   repo: https://github.com/pycqa/flake8
     # do flake8 last to avoid duplicate reports
     rev: 7.0.0

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -130,18 +130,18 @@ def create_web_component_html(
     try:
         js = requests.get(JS_BUNDLE_URL, timeout=10)
         js_status_code: Any = js.status_code
-    except requests.exceptions.ReadTimeout as e:
+    except requests.exceptions.ReadTimeout as e:  # pragma: no cover
         js_status_code = "TIMEOUT"
         LOGGER.warning(e)
 
     try:
         fonts = requests.get(FONTS_BUNDLE_URL, timeout=10)
         fonts_status_code: Any = fonts.status_code
-    except requests.exceptions.ReadTimeout as e:
+    except requests.exceptions.ReadTimeout as e:  # pragma: no cover
         LOGGER.warning(e)
         fonts_status_code = "TIMEOUT"
 
-    if js_status_code != 200:
+    if js_status_code != 200:  # pragma: no cover
         LOGGER.warning(
             f"Sorry, the JavaScript bundle that is supposed to be at {JS_BUNDLE_URL} returned a {js_status_code}. Your ReadAlong will be bundled using a version that may not be up-to-date. Please check your internet connection."
         )
@@ -149,10 +149,10 @@ def create_web_component_html(
             os.path.join(os.path.dirname(__file__), "bundle.js"), encoding="utf8"
         ) as f:
             js_raw = f.read()
-    else:
+    else:  # pragma: no cover
         js_raw = js.text
 
-    if fonts_status_code != 200:
+    if fonts_status_code != 200:  # pragma: no cover
         LOGGER.warning(
             f"Sorry, the fonts bundle that is supposed to be at {FONTS_BUNDLE_URL} returned a {fonts_status_code}. Your ReadAlong will be bundled using a version that may not be up-to-date. Please check your internet connection."
         )
@@ -160,7 +160,7 @@ def create_web_component_html(
             os.path.join(os.path.dirname(__file__), "bundle.css"), encoding="utf8"
         ) as f:
             fonts_raw = f.read()
-    else:
+    else:  # pragma: no cover
         fonts_raw = fonts.text
 
     return BASIC_HTML.format(

--- a/test/run.py
+++ b/test/run.py
@@ -13,6 +13,7 @@ where [suite] can be one of:
    other: run the other tests
 """
 
+import argparse
 import os
 import re
 import sys
@@ -97,7 +98,7 @@ def describe_suite(suite: TestSuite):
 SUITES = ["all", "dev", "e2e", "prod", "api", "other"]
 
 
-def run_tests(suite: str, describe: bool = False) -> bool:
+def run_tests(suite: str, describe: bool = False, verbosity=3) -> bool:
     """Run the specified test suite.
 
     Args:
@@ -131,7 +132,7 @@ def run_tests(suite: str, describe: bool = False) -> bool:
         describe_suite(test_suite)
         return True
     else:
-        runner = TextTestRunner(verbosity=3)
+        runner = TextTestRunner(verbosity=verbosity)
         success = runner.run(test_suite).wasSuccessful()
         if not success:
             LOGGER.error("Some tests failed. Please see log above.")
@@ -139,10 +140,19 @@ def run_tests(suite: str, describe: bool = False) -> bool:
 
 
 if __name__ == "__main__":
-    describe = "--describe" in sys.argv
-    if describe:
-        sys.argv.remove("--describe")
-
-    result = run_tests("" if len(sys.argv) <= 1 else sys.argv[1], describe)
+    parser = argparse.ArgumentParser(description="Run ReadAlongs/Studio test suites.")
+    parser.add_argument("--quiet", "-q", action="store_true", help="reduce output")
+    parser.add_argument(
+        "--describe", action="store_true", help="describe the selected test suite"
+    )
+    parser.add_argument(
+        "suite",
+        nargs="?",
+        default="dev",
+        help="the test suite to run [dev]",
+        choices=SUITES,
+    )
+    args = parser.parse_args()
+    result = run_tests(args.suite, args.describe, 1 if args.quiet else 3)
     if not result:
         sys.exit(1)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,6 +5,8 @@ Test suite for the API way to call align
 """
 
 import os
+from contextlib import redirect_stderr
+from io import StringIO
 from unittest import main
 
 import click
@@ -23,13 +25,14 @@ class TestAlignApi(BasicTestCase):
         # API accepts them too.
         langs = ("fra",)  # make sure language can be an iterable, not just a list.
         with SoundSwallowerStub("t0b0d0p0s0w0:920:1520", "t0b0d0p0s1w0:1620:1690"):
-            (status, exception, log) = api.align(
-                self.data_dir / "ej-fra.txt",
-                self.data_dir / "ej-fra.m4a",
-                self.tempdir / "output",
-                langs,
-                output_formats=["html", "TextGrid", "srt"],
-            )
+            with redirect_stderr(StringIO()):
+                (status, exception, log) = api.align(
+                    self.data_dir / "ej-fra.txt",
+                    self.data_dir / "ej-fra.m4a",
+                    self.tempdir / "output",
+                    langs,
+                    output_formats=["html", "TextGrid", "srt"],
+                )
         self.assertEqual(status, 0)
         self.assertTrue(exception is None)
         self.assertIn("Words (<w>) not present; tokenizing", log)
@@ -53,16 +56,18 @@ class TestAlignApi(BasicTestCase):
             "Make sure the API call doesn't not modify my variables",
         )
 
-        (status, exception, log) = api.align("", "", self.tempdir / "errors")
+        with redirect_stderr(StringIO()):
+            (status, exception, log) = api.align("", "", self.tempdir / "errors")
         self.assertNotEqual(status, 0)
         self.assertFalse(exception is None)
 
     def test_call_make_xml(self):
-        (status, exception, log) = api.make_xml(
-            self.data_dir / "ej-fra.txt",
-            self.tempdir / "prepared.readalong",
-            ("fra", "eng"),
-        )
+        with redirect_stderr(StringIO()):
+            (status, exception, log) = api.make_xml(
+                self.data_dir / "ej-fra.txt",
+                self.tempdir / "prepared.readalong",
+                ("fra", "eng"),
+            )
         self.assertEqual(status, 0)
         self.assertTrue(exception is None)
         self.assertIn("Wrote ", log)

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -41,9 +41,6 @@ class TestAudio(BasicTestCase):
             input_audio_path,
             output_path,
         ] + flags
-        LOGGER.info(
-            f"Aligning {input_text_path} and {input_audio_path}, outputting to {output_path}"
-        )
         return run(args, capture_output=True, check=False, encoding="utf-8")
 
     def test_mute_section(self):

--- a/test/test_dna_text.py
+++ b/test/test_dna_text.py
@@ -2,6 +2,8 @@
 
 """Test handling of DNA text in tokenization"""
 
+from contextlib import redirect_stderr
+from io import StringIO
 from unittest import main
 
 from basic_test_case import BasicTestCase
@@ -23,7 +25,8 @@ class TestDNAText(BasicTestCase):
 <s>Voici une deuxième phrase.</s>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         as_txt = etree.tounicode(tokenized)
         # print(etree.tounicode(tokenized))
 
@@ -54,7 +57,8 @@ class TestDNAText(BasicTestCase):
 <s>Un <foo do-not-align="1">mot ou deux</foo> à exclure.</s>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         as_txt = etree.tounicode(tokenized)
         # print('as_txt="' + as_txt +'"')
 
@@ -96,7 +100,8 @@ class TestDNAText(BasicTestCase):
 </div>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         as_txt = etree.tounicode(tokenized)
         # print('as_txt="' + as_txt +'"')
 
@@ -143,7 +148,8 @@ class TestDNAText(BasicTestCase):
 
         txt = """<s xml:lang="fra">Une <w do-not-align="true">exclude</w> phrase.</s>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         self.assertRaises(RuntimeError, add_ids, tokenized)
 
     def test_dna_word_nested(self):
@@ -151,7 +157,8 @@ class TestDNAText(BasicTestCase):
 
         txt = """<s xml:lang="fra">Une <foo do-not-align="true"><bar><w>exclude</w></bar></foo> phrase.</s>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         self.assertRaises(RuntimeError, add_ids, tokenized)
 
 

--- a/test/test_g2p_cli.py
+++ b/test/test_g2p_cli.py
@@ -4,6 +4,8 @@
 
 import os
 import re
+from contextlib import redirect_stderr
+from io import StringIO
 from unittest import main
 
 from basic_test_case import BasicTestCase
@@ -303,8 +305,9 @@ class TestG2pCli(BasicTestCase):
         self.assertIn('<w ARPABET="NOT ARPABET" id="s0w2">error</w>', results.output)
 
         audio_file = os.path.join(self.data_dir, "ej-fra.m4a")
-        with self.assertRaises(RuntimeError) as e:
-            results = align_audio(input_file, audio_file)
+        with redirect_stderr(StringIO()):
+            with self.assertRaises(RuntimeError) as e:
+                results = align_audio(input_file, audio_file)
         self.assertIn("could not be g2p'd", str(e.exception))
 
     def test_align_with_preg2p(self):
@@ -330,9 +333,10 @@ class TestG2pCli(BasicTestCase):
             "t0b0d0p0s3w2:15:16",
             "t0b0d0p0s3w3:16:17",
         ):
-            _ = align_audio(
-                text_file, audio_file, save_temps=os.path.join(self.tempdir, "foo")
-            )
+            with redirect_stderr(StringIO()):
+                _ = align_audio(
+                    text_file, audio_file, save_temps=os.path.join(self.tempdir, "foo")
+                )
         with open(os.path.join(self.tempdir, "foo.dict"), "r", encoding="utf8") as f:
             dict_file = f.read()
             self.assertIn("S AH S IY", dict_file)  # "ceci" in fra
@@ -452,7 +456,8 @@ class TestG2pCli(BasicTestCase):
         self.assertTrue(valid, "convert_xml with valid pre-g2p'd text")
 
         xml = parse_xml('<s><w ARPABET="invalid">invalid</w></s>')
-        c_xml, valid = convert_xml(xml)
+        with redirect_stderr(StringIO()):
+            c_xml, valid = convert_xml(xml)
         self.assertEqual(
             etree.tounicode(c_xml), '<s><w ARPABET="invalid">invalid</w></s>'
         )

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -293,9 +293,9 @@ class TestMisc(BasicTestCase):
         with capture_logs() as captured_logs:
             LOGGER.info("this will be captured")
         self.assertIn("this will be captured", captured_logs.getvalue())
-        with self.assertLogs():
+        with self.assertLogs(LOGGER):
             LOGGER.info("blah")
-        with self.assertLogs() as cm:
+        with self.assertLogs(LOGGER) as cm:
             with capture_logs() as captured_logs:
                 LOGGER.info("This text does not propagate to root")
             LOGGER.info("This text is included in root")

--- a/test/test_tokenize_xml.py
+++ b/test/test_tokenize_xml.py
@@ -2,6 +2,8 @@
 
 """Unit test suite for our XML tokenizer module"""
 
+from contextlib import redirect_stderr
+from io import StringIO
 from unittest import TestCase, main
 
 from lxml import etree
@@ -23,7 +25,8 @@ class TestTokenizer(TestCase):
 <s xml:lang="atj"><w>Kwei</w>! <w>Tan</w> <w>e</w> <w>ici</w> <w>matisihin</w>?</s>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         # print(etree.tounicode(tokenized))
         self.assertEqual(etree.tounicode(tokenized), ref)
 
@@ -39,7 +42,8 @@ class TestTokenizer(TestCase):
 <s xml:lang="fra"><w>Bonjour</w>! <w>Comment</w> <w>ça</w> <w>va</w>?</s>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         # print(etree.tounicode(tokenized))
         self.assertEqual(etree.tounicode(tokenized), ref)
 
@@ -55,7 +59,8 @@ class TestTokenizer(TestCase):
 <s xml:lang="atj">Tan e ici matisihin?</s>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         # print(etree.tounicode(tokenized))
         self.assertEqual(etree.tounicode(tokenized), ref)
 
@@ -73,7 +78,8 @@ class TestTokenizer(TestCase):
 <s xml:lang="atj"><w>Tan</w> <w>e</w> <w>ici</w> <w>matisihin</w>?</s>
 </document>"""
         xml = parse_xml(txt)
-        tokenized = tokenize_xml.tokenize_xml(xml)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml.tokenize_xml(xml)
         # print(etree.tounicode(tokenized))
         self.assertEqual(etree.tounicode(tokenized), ref)
 

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+from contextlib import redirect_stderr
+from io import StringIO
 from textwrap import dedent
 from unittest import main
 
@@ -46,17 +48,20 @@ class TestWebApi(BasicTestCase):
             "type": "text/plain",
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 200)
 
     def test_bad_path(self):
         # Test a request to a path that doesn't exist
-        response = self.API_CLIENT.get("/pathdoesntexist")
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.get("/pathdoesntexist")
         self.assertEqual(response.status_code, 404)
 
     def test_bad_method(self):
         # Test a request to a valid path with a bad method
-        response = self.API_CLIENT.get("/api/v1/assemble")
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.get("/api/v1/assemble")
         self.assertEqual(response.status_code, 405)
 
     def test_assemble_from_xml(self):
@@ -67,7 +72,8 @@ class TestWebApi(BasicTestCase):
             "type": "application/readalong+xml",
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 200)
 
     def test_illformed_xml(self):
@@ -77,7 +83,8 @@ class TestWebApi(BasicTestCase):
             "type": "application/readalong+xml",
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
 
     def test_invalid_ras(self):
@@ -87,13 +94,15 @@ class TestWebApi(BasicTestCase):
             "type": "application/readalong+xml",
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
 
     def test_create_grammar(self):
         # Test the create grammar function
         parsed = parse_xml(self.slurp_data_file("ej-fra.readalong"))
-        tokenized = tokenize_xml(parsed)
+        with redirect_stderr(StringIO()):
+            tokenized = tokenize_xml(parsed)
         ids_added = add_ids(tokenized)
         g2ped, valid = convert_xml(ids_added)
         from readalongs.web_api import create_grammar
@@ -110,7 +119,8 @@ class TestWebApi(BasicTestCase):
             "type": "text/plain",
             "text_languages": ["test"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertIn("No language called", response.json()["detail"])
         self.assertEqual(response.status_code, 422)
 
@@ -121,7 +131,8 @@ class TestWebApi(BasicTestCase):
             "type": "text/plain",
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
         content = response.json()
         self.assertIn("No valid g2p conversion", content["detail"])
@@ -133,7 +144,8 @@ class TestWebApi(BasicTestCase):
             "type": "text/plain",
             "text_languages": ["eng"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
         content = response.json()
         self.assertIn("Could not find any words", content["detail"])
@@ -146,7 +158,8 @@ class TestWebApi(BasicTestCase):
             "type": "text/plain",
             "text_languages": ["eng", "und"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
         content_log = response.json()["detail"]
         for message_part in ["The output of the g2p process", "24", "23", "is empty"]:
@@ -154,7 +167,8 @@ class TestWebApi(BasicTestCase):
 
     def test_langs(self):
         # Test the langs endpoint
-        response = self.API_CLIENT.get("/api/v1/langs")
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.get("/api/v1/langs")
         codes = [x["code"] for x in response.json()]
         self.assertEqual(set(codes), set(get_langs()[0]))
         self.assertEqual(codes, list(sorted(codes)))
@@ -170,7 +184,8 @@ class TestWebApi(BasicTestCase):
             "debug": True,
             "text_languages": ["fra", "und"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         content = response.json()
         # print("Content", content)
         self.assertIn('Could not g2p "ña" as French', content["log"])
@@ -183,7 +198,8 @@ class TestWebApi(BasicTestCase):
             "debug": True,
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         content = response.json()
         self.assertEqual(content["input"], request)
         self.assertGreater(len(content["tokenized"]), 10)
@@ -196,7 +212,8 @@ class TestWebApi(BasicTestCase):
             "type": "text/plain",
             "text_languages": ["fra"],
         }
-        response = self.API_CLIENT.post("/api/v1/assemble", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         content = response.json()
         self.assertIsNone(content["input"])
         self.assertIsNone(content["tokenized"])
@@ -229,9 +246,10 @@ class TestWebApi(BasicTestCase):
             "dur": 83.1,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/textgrid", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/textgrid", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("aligned.TextGrid", response.headers["content-disposition"])
         self.assertEqual(
@@ -293,9 +311,10 @@ class TestWebApi(BasicTestCase):
         request = {
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/textgrid", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/textgrid", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("aligned.TextGrid", response.headers["content-disposition"])
         self.assertNotIn("xmax = 83.100000", response.text)
@@ -305,7 +324,10 @@ class TestWebApi(BasicTestCase):
             "dur": 83.1,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post("/api/v1/convert_alignment/eaf", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/eaf", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("<ANNOTATION_DOCUMENT", response.text)
         self.assertIn("aligned.eaf", response.headers["content-disposition"])
@@ -315,7 +337,10 @@ class TestWebApi(BasicTestCase):
             "dur": 83.1,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post("/api/v1/convert_alignment/srt", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/srt", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("aligned_sentences.srt", response.headers["content-disposition"])
         self.assertEqual(
@@ -330,9 +355,10 @@ class TestWebApi(BasicTestCase):
             ),
         )
 
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/srt?tier=word", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/srt?tier=word", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("aligned_words.srt", response.headers["content-disposition"])
         self.assertEqual(
@@ -357,9 +383,10 @@ class TestWebApi(BasicTestCase):
             "dur": 83.1,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/vtt?tier=sentence", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/vtt?tier=sentence", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("aligned_sentences.vtt", response.headers["content-disposition"])
         self.assertEqual(
@@ -374,9 +401,10 @@ class TestWebApi(BasicTestCase):
             ),
         )
 
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/vtt?tier=word", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/vtt?tier=word", json=request
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn("aligned_words.vtt", response.headers["content-disposition"])
         self.assertEqual(
@@ -399,18 +427,20 @@ class TestWebApi(BasicTestCase):
             "dur": 83.1,
             "ras": "this is not XML",
         }
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/textgrid", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/textgrid", json=request
+            )
         self.assertEqual(response.status_code, 422, "Invalid XML should fail.")
 
         request = {
             "dur": -10.0,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/textgrid", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/textgrid", json=request
+            )
         self.assertEqual(response.status_code, 422, "Negative duration should fail.")
 
     def test_cleanup_temp_dir(self):
@@ -481,21 +511,24 @@ class TestWebApi(BasicTestCase):
             "dur": 83.1,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/badformat", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/badformat", json=request
+            )
         self.assertEqual(response.status_code, 422)
 
         request = {
             "dur": 83.1,
             "ras": self.hej_verden_xml,
         }
-        response = self.API_CLIENT.post("/api/v1/convert_alignment", json=request)
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post("/api/v1/convert_alignment", json=request)
         self.assertEqual(response.status_code, 404)
 
-        response = self.API_CLIENT.post(
-            "/api/v1/convert_alignment/vtt?tier=badtier", json=request
-        )
+        with redirect_stderr(StringIO()):
+            response = self.API_CLIENT.post(
+                "/api/v1/convert_alignment/vtt?tier=badtier", json=request
+            )
         self.assertEqual(response.status_code, 422)
 
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Reduce the amount of output we get from running test test suites.

Now, `test/run.py --quiet` (using this new option I added), you get just dots:

```
$ test/run.py --quiet
INFO - No test suite specified, defaulting to dev.
..........................................................................................................................................
----------------------------------------------------------------------
Ran 138 tests in 39.697s

OK
```
like a well-behaved test suite.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

my annoyance at verbose test suite output

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

it's only tests...

### How to test? <!-- Explain how reviewers should test this PR. -->

Run `test/run.py` and `test/run.py --quiet` and enjoy the (relative) silence.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
