### PR TITLE
Dev.ej/py313

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/requirements.min.txt
+++ b/requirements.min.txt
@@ -1,10 +1,11 @@
 # This is the minimal set of dependencies required for the readalongs package
+audioop-lts; python_version>='3.13'
 chevron==0.14.0
 click>=8.0.4
 coloredlogs>=10.0
 fastapi>=0.103.0
 g2p>=1.1.20230822, <3
-lxml==4.9.4
+lxml>=4.9.4
 numpy>=1.20.2
 pydantic>=1.8.2,<3
 pydub>=0.23.1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     entry_points={"console_scripts": ["readalongs = readalongs.cli:cli"]},
     classifiers=[
         "Programming Language :: Python :: 3",
-        *[f"Programming Language :: Python :: 3.{minor}" for minor in range(8, 13)],
+        *[f"Programming Language :: Python :: 3.{minor}" for minor in range(8, 14)],
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Support Python 3.13

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Addresses compatibility problems between some of our dependencies and Python 3.13

 - `audioop` has been removed from Python 3.13 standard libraries, but `pydub` still requires it. The community has rallied to fix this, in the form of `audioop-lts`, which we only need for Python >= 3.13
 - lxml 4.9.4 doesn't support Python 3.13. I'm not sure why we were locking the version anyway, so I just made it `>=` instead of `==`. It to work just fine. The several lxlm 5.x releases don't list any breaking changes.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes, added Py 3.13 to matrix testing (and it passes)

### How to test? <!-- Explain how reviewers should test this PR. -->

install on Python 3.13 and have fun

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

maybe a patch bump so `pip install readalongs` will work for Python 3.13.

### Related PRs

https://github.com/ReadAlongs/SoundSwallower/pull/67



<!-- Add any other relevant information here -->

