### PR TITLE
perf: cache the bundles after we fetched them once

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -190,6 +190,20 @@ class TestAlignApi(BasicTestCase):
         )
         self.assertEqual(html, html2)
 
+        # Once more, this time pretend we could not fetch the first bundle
+        make_package.fonts_bundle_contents = None
+        make_package.js_bundle_contents = None
+        make_package._prev_js_status_code = "TIMEOUT"
+        make_package._prev_fonts_status_code = None
+        _, _ = api.convert_prealigned_text_to_offline_html(
+            self.sentences_to_convert,
+            str(self.data_dir / "noise.mp3"),
+            subheader="by Jove!",
+        )
+        self.assertEqual(make_package._prev_fonts_status_code, "TIMEOUT")
+        self.assertIsNotNone(make_package.fonts_bundle_contents)
+        self.assertIsNotNone(make_package.js_bundle_contents)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

For a process using `convert_prealigned_text_to_offline_html()` in the Studio API to create a number of different readalongs, fetching the bundles is pretty slow, and has to be done repeatedly for each readalong created. Running the EveryVoice demo on our cluster, that represented an additional 3 second delay each time I clicked the synthesize button, on top of the actual synthesis time.

The solution I adopted here is simply to save the bundle contents in a file-global variable in `make_package.py`, so we only ever try to fetch each of the two bundle files once.

Memory cost: the bundles take 600KB together, so after the first fetch I'm reserving .6MB for this cache, which is pretty trivial.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

low

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

~code already covered~

Yes

### How to test? <!-- Explain how reviewers should test this PR. -->

Run the everyvoice demo with this branch of Studio vs main, and see synthesis run faster the second and subsequent time.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

Patch, but only when we decide we really want this included in the EV demo...

<!-- Add any other relevant information here -->
