### PR TITLE
fix: enforce time limit on assemble as a whole, not just g2p

### DIFF
--- a/readalongs/text/convert_xml.py
+++ b/readalongs/text/convert_xml.py
@@ -72,7 +72,8 @@ def convert_words(  # noqa: C901
     word_unit: str = "w",
     output_orthography: str = "eng-arpabet",
     verbose_warnings: Optional[bool] = False,
-    time_limit: Optional[int] = None,
+    time_limit: Optional[float] = None,
+    start_time: Optional[float] = None,
 ):
     """Helper for convert_xml(), with the same Args and Return values, except
     xml is modified in place returned itself, instead of making a copy.
@@ -202,7 +203,8 @@ def convert_words(  # noqa: C901
         return result
 
     all_g2p_valid = True
-    start_time = perf_counter()
+    if start_time is None:
+        start_time = perf_counter()
     for i, word in enumerate(xml.xpath(".//" + word_unit)):
         if time_limit is not None and perf_counter() - start_time > time_limit:
             raise TimeLimitException(
@@ -262,7 +264,8 @@ def convert_xml(
     word_unit: str = "w",
     output_orthography: str = "eng-arpabet",
     verbose_warnings: Optional[bool] = False,
-    time_limit: Optional[int] = None,
+    time_limit: Optional[float] = None,
+    start_time: Optional[float] = None,
 ):
     """Convert all the words in XML though g2p, putting the results in attribute ARPABET
 
@@ -272,6 +275,9 @@ def convert_xml(
         output_orthography: target language for g2p mappings
         verbose_warnings: whether (very!) verbose g2p errors should be produced
         time_limit: if not None, maximum time in seconds to spend on g2p conversion
+        start_time: when the clock started for enforcing the time limit; if not None,
+                    must have been set by calling time.perf_counter() at the beginning
+                    of the calling process
 
     Returns:
         xml (etree), valid (bool):
@@ -284,6 +290,11 @@ def convert_xml(
     """
     xml_copy = copy.deepcopy(xml)
     xml_copy, valid = convert_words(
-        xml_copy, word_unit, output_orthography, verbose_warnings, time_limit
+        xml_copy,
+        word_unit,
+        output_orthography,
+        verbose_warnings,
+        time_limit,
+        start_time,
     )
     return xml_copy, valid


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

I can still generate 503 with large text via the API, so this PR enforces the time limit on the whole of assemble, not just on g2p processing.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

before ICLDC

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

requires messing with the API directly, giving it a very large payload.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
