### PR TITLE
feat: summarize g2p errors in assemble and on the CLI

### DIFF
--- a/readalongs/align_utils.py
+++ b/readalongs/align_utils.py
@@ -58,7 +58,7 @@ def parse_and_make_xml(
     xml = add_ids(xml)
     if save_temps is not None:
         save_xml(save_temps + ".ids.readalong", xml)
-    xml, valid = convert_xml(
+    xml, valid, non_convertible_words = convert_xml(
         xml,
         verbose_warnings=verbose_g2p_warnings,
         output_orthography=output_orthography,
@@ -67,8 +67,10 @@ def parse_and_make_xml(
         save_xml(save_temps + ".g2p.readalong", xml)
     if not valid:
         raise RuntimeError(
-            "Some words could not be g2p'd correctly. Aborting. "
-            "Run with --debug-g2p for more detailed g2p error logs."
+            "These words could not be g2p'd correctly: '"
+            + "', '".join(non_convertible_words)
+            + "'. Aborting. "
+            + "Run with --debug-g2p for more detailed g2p error logs."
         )
     return xml
 

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -749,7 +749,9 @@ def g2p(**kwargs):
     xml = add_ids(xml)
 
     # Apply the g2p mappings.
-    xml, valid = convert_xml(xml, verbose_warnings=kwargs["debug_g2p"])
+    xml, valid, non_convertible_words = convert_xml(
+        xml, verbose_warnings=kwargs["debug_g2p"]
+    )
 
     if output_path == "-":
         write_xml(sys.stdout.buffer, xml)
@@ -759,7 +761,9 @@ def g2p(**kwargs):
 
     if not valid:
         LOGGER.error(
-            "Some word(s) could not be g2p'd correctly."
+            "These word(s) could not be g2p'd correctly: '"
+            + "', '".join(non_convertible_words)
+            + "'."
             + (
                 " Run again with --debug-g2p to get more detailed error messages."
                 if not kwargs["debug_g2p"]

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -116,7 +116,7 @@ def encode_from_path(path: Union[str, os.PathLike]) -> str:
     return f"data:{mime_type};base64,{b64}"
 
 
-def fetch_bundle_file(url, filename, prev_status_code):
+def fetch_bundle_file(url: str, filename: str, prev_status_code: Any):
     """Fetch either of the online bundles, or their on-disk fallback if needed."""
     import requests  # Defer expensive import
 

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -259,7 +259,7 @@ async def assemble(
 
         # g2p
         try:
-            g2ped, valid = convert_xml(
+            g2ped, valid, non_convertible_words = convert_xml(
                 ids_added,
                 start_time=start_time,
                 time_limit=ASSEMBLE_TIME_LIMIT_IN_SECONDS,
@@ -268,10 +268,18 @@ async def assemble(
             raise HTTPException(status_code=422, detail=str(e)) from e
 
         if not valid:
+            if non_convertible_words:
+                logs = (
+                    "These words could not be converted from text to phonemes by g2p: '"
+                    + "', '".join(non_convertible_words)
+                    + "'."
+                )
+            else:
+                logs = "Logs: " + captured_logs.getvalue()
             raise HTTPException(
                 status_code=422,
-                detail="g2p could not be performed, please check your text or your language code. Logs: "
-                + captured_logs.getvalue(),
+                detail="g2p could not be performed, please check your text or your language code. "
+                + logs,
             )
         # create grammar
         dict_data, text_input = create_grammar(g2ped)

--- a/test/test_web_api.py
+++ b/test/test_web_api.py
@@ -105,7 +105,7 @@ class TestWebApi(BasicTestCase):
         with redirect_stderr(StringIO()):
             tokenized = tokenize_xml(parsed)
         ids_added = add_ids(tokenized)
-        g2ped, valid = convert_xml(ids_added)
+        g2ped, valid, _ = convert_xml(ids_added)
 
         word_dict, text = create_grammar(g2ped)
         self.assertTrue(valid)
@@ -159,11 +159,11 @@ class TestWebApi(BasicTestCase):
                 ids_added, time_limit=1.001, start_time=perf_counter() - 1.0
             )
         # Lots of time, should not raise
-        _, valid = convert_xml(
+        _, valid, _ = convert_xml(
             ids_added, time_limit=100, start_time=perf_counter() - 1.0
         )
         self.assertTrue(valid)
-        _, valid = convert_xml(ids_added, time_limit=100)
+        _, valid, _ = convert_xml(ids_added, time_limit=100)
         self.assertTrue(valid)
 
     def test_bad_g2p(self):
@@ -189,7 +189,7 @@ class TestWebApi(BasicTestCase):
             response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
         content = response.json()
-        self.assertIn("No valid g2p conversion", content["detail"])
+        self.assertIn("These words could not", content["detail"])
 
     def test_no_words(self):
         # Test the assemble endpoint with no actual words in the text
@@ -216,7 +216,7 @@ class TestWebApi(BasicTestCase):
             response = self.API_CLIENT.post("/api/v1/assemble", json=request)
         self.assertEqual(response.status_code, 422)
         content_log = response.json()["detail"]
-        for message_part in ["The output of the g2p process", "24", "23", "is empty"]:
+        for message_part in ["These words could not", "24", "23"]:
             self.assertIn(message_part, content_log)
 
     def test_langs(self):


### PR DESCRIPTION
### PR Goal? <!-- Explain the main objective of this PR. -->

In assemble, just list the words that could not be g2p'd, so the error message shown to the user in Studio-Web is legible.

In the CLI, add a summary list of the words that could not be g2p's in the error message.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->




### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

Unreadably verbose errors shown to users in Studio-Web when some tokens cannot be g2p'd.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanity checking

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

before ICLDC ideally

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

yes

### How to test? <!-- Explain how reviewers should test this PR. -->

In Studio:
```
./run_web_api.sh
```

In Studio-Web:
```
npx nx build web-component
npx nx serve studio-web
```

Navigate to http://localhost:4200/ and put non-g2p-able text like `54:23 1223:563 54:23` and see the nice and sweet error message like this when you click on next step:
![{59EF933A-DF50-439C-95EE-BD8861BA66EA}](https://github.com/user-attachments/assets/e34da6b8-db51-4301-8c6a-52241b465166)


### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

Before ICLDC, I might choose to bump Studio's version to 1.2.2 with the several little patches we've done recently.

<!-- Add any other relevant information here -->
