### PR TITLE
Several improvements to the HTML files created by RAS CLI

### DIFF
--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -22,12 +22,10 @@ from lxml import etree
 
 from readalongs._version import VERSION
 from readalongs.log import LOGGER
-from readalongs.text.util import parse_xml
+from readalongs.text.util import CURRENT_WEB_APP_VERSION, parse_xml
 
-JS_BUNDLE_URL = "https://unpkg.com/@readalongs/web-component@^1.5.2/dist/bundle.js"
-FONTS_BUNDLE_URL = (
-    "https://unpkg.com/@readalongs/web-component@^1.5.2/dist/fonts.b64.css"
-)
+JS_BUNDLE_URL = f"https://unpkg.com/@readalongs/web-component@^{CURRENT_WEB_APP_VERSION}/dist/bundle.js"
+FONTS_BUNDLE_URL = f"https://unpkg.com/@readalongs/web-component@^{CURRENT_WEB_APP_VERSION}/dist/fonts.b64.css"
 
 BASIC_HTML = """
 <!DOCTYPE html>

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -27,6 +27,7 @@ from readalongs.text.util import CURRENT_WEB_APP_VERSION, parse_xml
 JS_BUNDLE_URL = f"https://unpkg.com/@readalongs/web-component@^{CURRENT_WEB_APP_VERSION}/dist/bundle.js"
 FONTS_BUNDLE_URL = f"https://unpkg.com/@readalongs/web-component@^{CURRENT_WEB_APP_VERSION}/dist/fonts.b64.css"
 
+# Template for the Offline HTML file
 BASIC_HTML = """
 <!DOCTYPE html>
 
@@ -59,14 +60,23 @@ To view the file:
   <meta name="application-name" content="read along">
   <meta name="generator" content="@readalongs/studio (cli) {studio_version}">
   <title>{title}</title>
-  <script>{js}</script>
-  <style attribution="See https://fonts.google.com/attribution for copyrights and font attribution">{fonts}</style>
+  <script>
+{js}
+  </script>
+  <style attribution="See https://fonts.google.com/attribution for copyrights and font attribution">
+{fonts}
+  </style>
 </head>
 <body>
-    <read-along href="{ras}" audio="{audio}" theme="{theme}" use-assets-folder="false">
-        <span slot='read-along-header'>{header}</span>
-        <span slot='read-along-subheader'>{subheader}</span>
-    </read-along>
+  <read-along
+    href="{ras}"
+    audio="{audio}"
+    theme="{theme}"
+    use-assets-folder="false"
+  >
+    <span slot='read-along-header'>{header}</span>
+    <span slot='read-along-subheader'>{subheader}</span>
+  </read-along>
 </body>
 </html>
 """

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -31,6 +31,29 @@ FONTS_BUNDLE_URL = (
 
 BASIC_HTML = """
 <!DOCTYPE html>
+
+<!--
+
+                    Instructions for Opening this File
+
+This is a read-along file that can be opened in a web browser without
+requiring Internet access.
+
+If you see this text, you probably downloaded a ReadAlong HTML file from a
+cloud storage service, and it's showing you the raw contents instead of
+displaying your readalong.
+
+To view the file:
+
+1. Download the file to your computer -- there should be a download button
+    visible or hidden in the three dot menu in your cloud storage service.
+
+2. Once downloaded, open the file in a web browser. You can do this by
+    double-clicking it in your file explorer or in your browser's downloaded
+    files list.
+
+-->
+
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -17,6 +17,7 @@ import os
 import re
 from base64 import b64encode
 from mimetypes import guess_type
+from textwrap import indent
 from typing import Any, Union
 
 from lxml import etree
@@ -55,30 +56,30 @@ To view the file:
 -->
 
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
-  <meta name="application-name" content="read along">
-  <meta name="generator" content="@readalongs/studio (cli) {studio_version}">
-  <title>{title}</title>
-  <script name="@readalongs/web-component" version="{js_version}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+    <meta name="application-name" content="read along">
+    <meta name="generator" content="@readalongs/studio (cli) {studio_version}">
+    <title>{title}</title>
+    <script name="@readalongs/web-component" version="{js_version}">
 {js}
-  </script>
-  <style attribution="See https://fonts.google.com/attribution for copyrights and font attribution">
+    </script>
+    <style attribution="See https://fonts.google.com/attribution for copyrights and font attribution">
 {fonts}
-  </style>
-</head>
-<body>
-  <read-along
-    href="{ras}"
-    audio="{audio}"
-    theme="{theme}"
-    use-assets-folder="false"
-  >
-    <span slot='read-along-header'>{header}</span>
-    <span slot='read-along-subheader'>{subheader}</span>
-  </read-along>
-</body>
+    </style>
+  </head>
+  <body>
+    <read-along
+      href="{ras}"
+      audio="{audio}"
+      theme="{theme}"
+      use-assets-folder="false"
+    >
+      <span slot='read-along-header'>{header}</span>
+      <span slot='read-along-subheader'>{subheader}</span>
+    </read-along>
+  </body>
 </html>
 """
 
@@ -215,6 +216,7 @@ def create_web_component_html(
         _prev_js_status_code, js_bundle_contents, js_bundle_version = fetch_bundle_file(
             JS_BUNDLE_URL, "bundle.js", _prev_js_status_code
         )
+        js_bundle_contents = indent(js_bundle_contents, " " * 6)
 
     global fonts_bundle_contents
     if fonts_bundle_contents is None:
@@ -225,6 +227,7 @@ def create_web_component_html(
         _prev_fonts_status_code, fonts_bundle_contents, _ = fetch_bundle_file(
             FONTS_BUNDLE_URL, "bundle.css", _prev_fonts_status_code
         )
+        fonts_bundle_contents = indent(fonts_bundle_contents, " " * 6)
 
     return BASIC_HTML.format(
         ras=encode_from_path(ras_path),

--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -249,7 +249,7 @@ MINIMAL_INDEX_HTML_TEMPLATE = """<!DOCTYPE html>
   </body>
 
   <!-- The last step needed is to import the package -->
-  <script type="module" src='https://unpkg.com/@readalongs/web-component@{version}/dist/web-component/web-component.esm.js'></script>
+  <script type="module" src='https://unpkg.com/@readalongs/web-component@^{version}/dist/web-component/web-component.esm.js'></script>
 </html>
 """
 

--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -225,26 +225,31 @@ def copy_file_to_zip(zip_path, origin_path, destination_path):
 
 MINIMAL_INDEX_HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="application-name" content="read along">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
-        <meta name="generator" content="@readalongs/studio (cli) {studio_version}">
-        <title>{title}</title>
-        <!-- Import fonts. Material Icons are needed by the web component -->
-        <link href="https://fonts.googleapis.com/css?family=Lato%7CMaterial+Icons%7CMaterial+Icons+Outlined" rel="stylesheet">
-    </head>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="application-name" content="read along">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
+    <meta name="generator" content="@readalongs/studio (cli) {studio_version}">
+    <title>{title}</title>
+    <!-- Import fonts. Material Icons are needed by the web component -->
+    <link href="https://fonts.googleapis.com/css?family=Lato%7CMaterial+Icons%7CMaterial+Icons+Outlined" rel="stylesheet">
+  </head>
 
-    <body>
-        <!-- Here is how you declare the Web Component. Supported languages: eng, fra, spa -->
-        <read-along href="{text}" audio="{audio}" theme="{theme}" language="eng">
-            <span slot='read-along-header'>{header}</span>
-            <span slot='read-along-subheader'>{subheader}</span>
-        </read-along>
-    </body>
+  <body>
+    <!-- Here is how you declare the Web Component. Supported languages: eng, fra, spa -->
+    <read-along
+      href="{text}"
+      audio="{audio}"
+      theme="{theme}"
+      language="eng"
+    >
+      <span slot='read-along-header'>{header}</span>
+      <span slot='read-along-subheader'>{subheader}</span>
+    </read-along>
+  </body>
 
-    <!-- The last step needed is to import the package -->
-    <script type="module" src='https://unpkg.com/@readalongs/web-component@{version}/dist/web-component/web-component.esm.js'></script>
+  <!-- The last step needed is to import the package -->
+  <script type="module" src='https://unpkg.com/@readalongs/web-component@{version}/dist/web-component/web-component.esm.js'></script>
 </html>
 """
 

--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -23,8 +23,8 @@ from readalongs._version import VERSION
 # removed "try: unicode() except" block (was for Python 2), but this file uses unicode()
 # too many times, so define it anyway.
 unicode = str
-# todo: sync with web component major and minor releases
-CURRENT_WEB_APP_VERSION = "1.4.x"
+# TODO: auto sync with web component major and minor releases
+CURRENT_WEB_APP_VERSION = "1.5.x"
 
 
 def ensure_dirs(path):

--- a/test/test_align_cli.py
+++ b/test/test_align_cli.py
@@ -72,10 +72,13 @@ class TestAlignCli(BasicTestCase):
                 (output / f).exists(), f"successful alignment should have created {f}"
             )
         with open(output / "www/index.html", encoding="utf8") as f:
-            self.assertIn(
-                '<read-along href="output.readalong" audio="output.m4a"',
-                f.read(),
-            )
+            contents = f.read()
+            for snippet in (
+                "<read-along",
+                'href="output.readalong"',
+                'audio="output.m4a"',
+            ):
+                self.assertIn(snippet, contents)
         self.assertTrue(
             (output / "tempfiles/output.tokenized.readalong").exists(),
             "alignment with -s should have created tempfiles/output.tokenized.readalong",

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -173,7 +173,7 @@ class TestAlignApi(BasicTestCase):
         self.assertIn("<html", html)
         self.assertIn("<body", html)
         self.assertIn('<meta name="generator" content="@readalongs/studio (cli)', html)
-        self.assertIn('<read-along href="data:application/readalong+xml;base64', html)
+        self.assertIn('href="data:application/readalong+xml;base64', html)
         self.assertIn('audio="data:audio/', html)
         self.assertIn("<span slot='read-along-header'>", html)
         self.assertIn("<span slot='read-along-subheader'>by Jove!</span>", html)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -11,7 +11,7 @@ from io import StringIO
 from unittest import main
 
 import click
-from basic_test_case import BasicTestCase
+from basic_test_case import BasicTestCase, silence_logs
 from sound_swallower_stub import SoundSwallowerStub
 
 from readalongs import api
@@ -203,6 +203,20 @@ class TestAlignApi(BasicTestCase):
         self.assertEqual(make_package._prev_fonts_status_code, "TIMEOUT")
         self.assertIsNotNone(make_package.fonts_bundle_contents)
         self.assertIsNotNone(make_package.js_bundle_contents)
+
+    def test_extract_version_from_url(self):
+        from readalongs.text.make_package import extract_version_from_url
+
+        # Test that the version is extracted correctly from the URL
+        url = "https://unpkg.com/@readalongs/web-component@1.2.3/dist/bundle.js"
+        version = extract_version_from_url(url)
+        self.assertEqual(version, "1.2.3")
+
+        # Test with a URL that doesn't contain a version
+        url = "https://unpkg.com/@readalongs/web-component/dist/bundle.js"
+        with silence_logs():
+            version = extract_version_from_url(url)
+        self.assertEqual(version, "unknown")
 
 
 if __name__ == "__main__":

--- a/test/test_package_urls.py
+++ b/test/test_package_urls.py
@@ -26,16 +26,19 @@ class TestPackageURLs(BasicTestCase):
     def test_fetch_bundles_fallback(self):
         """Test graceful exit when the URLs are not accessible."""
         # Pretend the previous attempt failed: we'll get the file from disk
-        status, contents = fetch_bundle_file(JS_BUNDLE_URL, "bundle.js", "SomeError")
+        status, contents, js_bundle_version = fetch_bundle_file(
+            JS_BUNDLE_URL, "bundle.js", "SomeError"
+        )
         # print(status, len(contents))
         self.assertEqual(status, "SomeError")
+        self.assertEqual(js_bundle_version, "unknown")
         ref_length = len(contents)
 
         # Try with a bad URL
         bad_url = JS_BUNDLE_URL.replace("unpkg.com", "not-a-server.zzz")
         # print(bad_url)
         with silence_logs():
-            status, contents = fetch_bundle_file(bad_url, "bundle.js", None)
+            status, contents, _ = fetch_bundle_file(bad_url, "bundle.js", None)
         # print(status, len(contents))
         self.assertNotEqual(status, 200)
         self.assertIsInstance(status, str)


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This work was triggered by noticing that a .html file someone just sent us was hard to analyse by hand, in terms of what versions of things were used. So I decided to add newlines so that the text part of stuff is still visible when you disable line-wrapping, and add more versioning information to the generated files. There will be a similar PR for S-Web soonish.

While I was there, I did some clean up and refactoring and added the instructions for opening the offline HTML file from Google Drive, copied from S-Web.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

General validation

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->



### How to test? <!-- Explain how reviewers should test this PR. -->

Use the CLI to create a readalong, with `-o html`, and look at the generated `www/index.html` and `Offline-HTML/<name>.html`.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

good

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

<!-- Add any other relevant information here -->
