### PR TITLE
Dev.ej/cli tweaks

### DIFF
--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -34,7 +34,7 @@ SUPPORTED_OUTPUT_FORMATS = {
 }
 
 SUPPORTED_OUTPUT_FORMATS_DESC = ", ".join(
-    k + f" ({v})" for k, v in SUPPORTED_OUTPUT_FORMATS.items()
+    k + f" ({v})" for k, v in SUPPORTED_OUTPUT_FORMATS.items() if k != "html"
 )
 
 
@@ -147,8 +147,8 @@ def cli():
     callback=JoinerCallbackForClick(SUPPORTED_OUTPUT_FORMATS, drop_case=True),
     help=(
         "Comma- or colon-separated list of additional output file formats to export to. "
-        "The text is always exported as XML and alignments as SMIL, but "
-        "one or more of these formats can be requested in addition:\b \n\n"
+        "The www bundle and Offline HTML are always generated, "
+        "but one or more of these formats can be requested in addition:\b \n\n"
         + SUPPORTED_OUTPUT_FORMATS_DESC
     ),
 )
@@ -402,6 +402,9 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
         # sys.exit(1)
 
     output_formats = kwargs["output_formats"]
+    # Now that Offline HTML is the editable format in Studio-Web, always generate it.
+    if "html" not in output_formats:
+        output_formats = [*output_formats, "html"]
 
     save_readalong(
         align_results=results,

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -428,6 +428,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
     context_settings=CONTEXT_SETTINGS,
     short_help="Renamed: use 'readalongs make-xml' instead.",
     deprecated=True,
+    hidden=True,
 )
 @click.argument("plaintextfile", type=click.File("r", encoding="utf-8-sig", lazy=True))
 @click.argument("xmlfile", type=click.Path(), required=False, default="")

--- a/readalongs/cli.py
+++ b/readalongs/cli.py
@@ -122,6 +122,14 @@ def cli():
     """
 
 
+LANGUAGES_DETAILS = (
+    "use 'und' for the generic language-independent mapping; "
+    "multiple codes can be joined by ',' or ':', or by repeating the option, "
+    "to enable the g2p cascade (run 'readalongs g2p -h' for details); "
+    "run 'readalongs langs' to list all supported languages."
+)
+
+
 @cli.command(  # type: ignore  # noqa: C901  # some versions of flake8 need this here
     context_settings=CONTEXT_SETTINGS, short_help="Force align a text and a sound file."
 )
@@ -189,9 +197,7 @@ def cli():
     callback=JoinerCallbackForClick(get_langs_deferred()),
     help=(
         "The language code(s) for text in TEXTFILE (use only with plain text input); "
-        "multiple codes can be joined by ',' or ':', or by repeating the option, "
-        "to enable the g2p cascade (run 'readalongs g2p -h' for details); "
-        "run 'readalongs langs' to list all supported languages."
+        + LANGUAGES_DETAILS
     ),
 )
 @click.option(
@@ -365,7 +371,8 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
         if not kwargs["language"]:
             raise click.BadParameter(
                 "No input language specified for plain text input. "
-                "Please provide the -l/--language switch."
+                "Please provide the -l/--language switch.\n"
+                "You can use '-l und' if you don't know the language or if it's not explicitly supported."
             )
         languages = list(kwargs["language"])
         if not kwargs["lang_no_append_und"] and "und" not in languages:
@@ -442,12 +449,7 @@ def align(**kwargs):  # noqa: C901  # some versions of flake8 need this here ins
     required=True,
     multiple=True,
     callback=JoinerCallbackForClick(get_langs_deferred()),
-    help=(
-        "The language code(s) for text in PLAINTEXTFILE; "
-        "multiple codes can be joined by ',' or ':', or by repeating the option, "
-        "to enable the g2p cascade (run 'readalongs g2p -h' for details); "
-        "run 'readalongs langs' to list all supported languages."
-    ),
+    help=("The language code(s) for text in PLAINTEXTFILE; " + LANGUAGES_DETAILS),
 )
 def prepare(**kwargs):
     """DEPRECATED - renamed: use `readalongs make-xml` instead.
@@ -494,12 +496,7 @@ def prepare(**kwargs):
     required=True,
     multiple=True,
     callback=JoinerCallbackForClick(get_langs_deferred()),
-    help=(
-        "The language code(s) for text in PLAINTEXTFILE; "
-        "multiple codes can be joined by ',' or ':', or by repeating the option, "
-        "to enable the g2p cascade (run 'readalongs g2p -h' for details); "
-        "run 'readalongs langs' to list all supported languages."
-    ),
+    help=("The language code(s) for text in PLAINTEXTFILE; " + LANGUAGES_DETAILS),
 )
 def make_xml(**kwargs):
     """make XMLFILE for 'readalongs align' from PLAINTEXTFILE.


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

While improving the documentation in #267 with Marc's feedback, there are three changes to the CLI I want to make, which I think should get their own separate review:

 - The most important is that I want to have `readalongs align` always generate the Offline HTML, like we do in Studio-Web, because it's the artefact that can be uploaded into the Editor.
 - Second: `readalongs prepare` has been marked deprecated for more than two years, I think we can hide it from the `readalongs -h` documentation.
 - Third: Marc pointed out `readalongs align` gives an error when `-l <lang>` is missing, but in S-Web we default to `und` instead. While not defaulting to `und` in the CLI (or should we?) I made `-l und` a more prominent thing, both in the help messages, and in the error message you get if you omit `-l`.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Most important: do you agree with systematically generating Offline HTML in `readalongs align`?

Basic review for the rest.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

This stuff is all already covered.

### How to test? <!-- Explain how reviewers should test this PR. -->

Run `readalongs align` without `-o html` and see that you still get `<output>/Offline-HTML/<output>.html`.

Run `readalongs -h` and see no mention of `prepare`

Run `readalongs align -h` and look at the `--language` documentation mentioning und explicitly.

Run `readalongs align` without the `-l` switch and notice the und mentioned in the error message.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

I'll do a patch bump once this and #267 are merged to update the published stable docs.

<!-- Add any other relevant information here -->
