### PR TITLE
fix: adds XML declarations to serialized read along documents

### DIFF
--- a/readalongs/api.py
+++ b/readalongs/api.py
@@ -67,7 +67,7 @@ from readalongs.text.make_package import (
     DEFAULT_TITLE,
     create_web_component_html,
 )
-from readalongs.text.util import parse_xml
+from readalongs.text.util import parse_xml, xml_to_string
 from readalongs.util import JoinerCallbackForClick, get_langs_deferred
 
 
@@ -263,12 +263,7 @@ def convert_prealigned_text_to_readalong(
                     sentence_xml.text += token.text
 
     xml = add_ids(xml)
-    xml_text = etree.tostring(
-        xml,
-        encoding="utf-8",
-        xml_declaration=True,
-    ).decode("utf8")
-
+    xml_text = xml_to_string(xml)
     return xml_text + "\n"
 
 

--- a/readalongs/text/make_package.py
+++ b/readalongs/text/make_package.py
@@ -126,7 +126,7 @@ def encode_from_path(path: Union[str, os.PathLike]) -> str:
                 )
                 continue
             img.attrib["url"] = f"data:{mime[0]};base64,{img_b64}"
-        path_bytes = etree.tostring(root)
+        path_bytes = etree.tostring(root, encoding="utf-8", xml_declaration=True)
     b64 = str(b64encode(path_bytes), encoding="utf8")
     mime = guess_type(path)
     if str(path).endswith(

--- a/readalongs/text/util.py
+++ b/readalongs/text/util.py
@@ -159,6 +159,10 @@ def save_xml(output_path, xml):
         write_xml(fout, xml)
 
 
+def xml_to_string(xml) -> str:
+    return etree.tostring(xml, encoding="utf-8", xml_declaration=True).decode()
+
+
 def save_xml_zip(zip_path, output_path, xml):
     ensure_dirs(zip_path)
     with zipfile.ZipFile(zip_path, "a", compression=zipfile.ZIP_DEFLATED) as fout_zip:

--- a/readalongs/web_api.py
+++ b/readalongs/web_api.py
@@ -52,7 +52,7 @@ from readalongs.text.add_ids_to_xml import add_ids
 from readalongs.text.convert_xml import TimeLimitException, convert_xml
 from readalongs.text.make_dict import make_dict_list
 from readalongs.text.tokenize_xml import tokenize_xml
-from readalongs.text.util import parse_xml
+from readalongs.text.util import parse_xml, xml_to_string
 from readalongs.util import get_langs
 
 # Heroku drops requests that take more than 30s total to respond, so give g2p a 25s budget
@@ -287,15 +287,15 @@ async def assemble(
     response = AssembleResponse(
         lexicon=dict_data,
         text_ids=text_input,
-        processed_ras=etree.tostring(g2ped, encoding="utf8").decode(),
+        processed_ras=xml_to_string(g2ped),
         log=captured_logs.getvalue(),
     )
 
     if request.debug:
         response.input_request = request
-        response.parsed = etree.tostring(parsed, encoding="utf8")
-        response.tokenized = etree.tostring(tokenized, encoding="utf8")
-        response.g2ped = etree.tostring(g2ped, encoding="utf8")
+        response.parsed = xml_to_string(parsed)
+        response.tokenized = xml_to_string(tokenized)
+        response.g2ped = xml_to_string(g2ped)
     return response
 
 


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Related to ReadAlongs/Studio-Web#426. Generated read alongs do not alway have the XML declaration. Centralized all `etree.tostring(... encoding="..." ).decode(...)` to `xml_to_string()` function utils.py.

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->



### Feedback sought? <!-- What should reviewers focus on in particular? -->

Confirmation that I've not broken anything.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium, non-blocking even if it will helpful in resolving Studio Web's issue.

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

None.

### How to test? <!-- Explain how reviewers should test this PR. -->

Any read along XML output should now contain the XML declaration.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

Medium-High.

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->



<!-- Add any other relevant information here -->
