### PR TITLE
build(deps): drop support for Python 3.8

### DIFF
--- a/.github/workflows/matrix-tests.yml
+++ b/.github/workflows/matrix-tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Optionally a book can be generated as a standalone HTML page, XHTML, Praat TextG
 
 ### The short version
 
-Install [FFmpeg](https://ffmpeg.org/) and Python 3.8 or higher.
+Install [FFmpeg](https://ffmpeg.org/) and Python 3.9 or higher.
 
 Run:
 
@@ -72,7 +72,7 @@ Run:
 
 Before you can install the ReadAlong Studio, you will need to install these dependencies:
 
- - Python, version 3.8 or higher,
+ - Python, version 3.9 or higher,
  - [FFmpeg](https://ffmpeg.org/),
  - a C compiler (sometimes required for some dependant libraries),
  - Git (optional, needed to get the current development version).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "readalongs"
 dynamic = ["version"]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 description = "ReadAlong Studio: Audiobook alignment for Indigenous languages"
 readme = "README.md"
 authors = [
@@ -26,12 +26,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Sound/Audio :: Speech",
     "Typing :: Typed",
 ]

--- a/readalongs/__init__.py
+++ b/readalongs/__init__.py
@@ -10,8 +10,8 @@ The main alignment module is readalongs.align.
 
 import sys
 
-if sys.version_info < (3, 8, 0):  # pragma: no cover
+if sys.version_info < (3, 9, 0):  # pragma: no cover
     sys.exit(
-        f"Python 3.8 or more recent is required. You are using {sys.version}. "
+        f"Python 3.9 or more recent is required. You are using {sys.version}. "
         "Please use a newer version of Python."
     )

--- a/tests/test_g2p_cli.py
+++ b/tests/test_g2p_cli.py
@@ -76,9 +76,10 @@ class TestG2pCli(BasicTestCase):
         self.assertTrue(os.path.exists(g2p_file))
 
         ref_file = os.path.join(self.data_dir, "mixed-langs.g2p.readalong")
-        with open(g2p_file, encoding="utf8") as output_f, open(
-            ref_file, encoding="utf8"
-        ) as ref_f:
+        with (
+            open(g2p_file, encoding="utf8") as output_f,
+            open(ref_file, encoding="utf8") as ref_f,
+        ):
             self.maxDiff = None
             # update version info
             ref_list = list(ref_f)

--- a/tests/test_make_xml_cli.py
+++ b/tests/test_make_xml_cli.py
@@ -95,9 +95,10 @@ class TestMakeXMLCli(BasicTestCase):
         self.assertEqual(results.exit_code, 0)
 
         ref_file = os.path.join(self.data_dir, "fra-prepared.readalong")
-        with open(xml_file, encoding="utf8") as output_f, open(
-            ref_file, encoding="utf8"
-        ) as ref_f:
+        with (
+            open(xml_file, encoding="utf8") as output_f,
+            open(ref_file, encoding="utf8") as ref_f,
+        ):
             self.maxDiff = None
             # update version info
             ref_list = list(ref_f)


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Python 3.8 is long EOL, and it prevents us from using `uv lock` on Windows. There is no value in keeping it anymore, so let's drop it.

### Feedback sought? <!-- What should reviewers focus on in particular? -->

confirmation we don't need Python 3.8 support anymore

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

normal

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

all well covered

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

no

### Related PR

https://github.com/NRC-ILT/g2p/pull/492

<!-- Add any other relevant information here -->
